### PR TITLE
Add cache service for config/provider data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ dist/
 node_modules
 .env
 .sessions
+_ralph

--- a/packages/app/src/server/handlers/providers/index.ts
+++ b/packages/app/src/server/handlers/providers/index.ts
@@ -6,6 +6,7 @@ import {
 } from '@shared/responses';
 import { Hono } from 'hono';
 import z from 'zod';
+import { cacheService } from '@server/services/cache';
 
 const MODELS_DEV_API = 'https://models.dev/api.json';
 const MODELS_DEV_LOGOS = 'https://models.dev/logos';
@@ -325,6 +326,11 @@ const app = new Hono()
           );
         }
 
+        await cacheService.delete(
+          `provider:${config.providerId}`,
+          'provider-configs'
+        );
+
         return c.json(successResponse(config, 200));
       } catch (error) {
         console.error('Error creating/updating provider config:', error);
@@ -367,6 +373,10 @@ const app = new Hono()
             404
           );
         }
+        await cacheService.delete(
+          `provider:${config.providerId}`,
+          'provider-configs'
+        );
         return c.json(successResponse(config, 200));
       } catch (error) {
         console.error('Error updating provider config:', error);
@@ -398,6 +408,10 @@ const app = new Hono()
             404
           );
         }
+        await cacheService.delete(
+          `provider:${config.providerId}`,
+          'provider-configs'
+        );
         return c.json(successResponse(config, 200));
       } catch (error) {
         console.error('Error deleting provider config:', error);

--- a/packages/app/src/server/handlers/targeting/index.ts
+++ b/packages/app/src/server/handlers/targeting/index.ts
@@ -6,6 +6,7 @@ import {
 } from '@shared/responses';
 import { Hono } from 'hono';
 import z from 'zod';
+import { cacheService } from '@server/services/cache';
 
 const app = new Hono()
   // Create a new targeting rule
@@ -39,6 +40,9 @@ const app = new Hono()
           enabled: body.enabled ?? true,
           conditions: body.conditions,
         });
+        if (rule) {
+          await cacheService.clear(`config:${rule.configId}`);
+        }
         return c.json(successResponse(rule, 200));
       } catch (error) {
         console.error('Error creating targeting rule:', error);
@@ -127,6 +131,7 @@ const app = new Hono()
             404
           );
         }
+        await cacheService.clear(`config:${rule.configId}`);
         return c.json(successResponse(rule, 200));
       } catch (error) {
         console.error('Error updating targeting rule:', error);
@@ -158,6 +163,7 @@ const app = new Hono()
             404
           );
         }
+        await cacheService.clear(`config:${rule.configId}`);
         return c.json(successResponse(rule, 200));
       } catch (error) {
         console.error('Error deleting targeting rule:', error);
@@ -291,6 +297,9 @@ const app = new Hono()
           configVariantId: body.configVariantId,
           variantVersionId: body.variantVersionId,
         });
+        if (rule) {
+          await cacheService.clear(`config:${rule.configId}`);
+        }
         return c.json(successResponse(rule, 200));
       } catch (error) {
         console.error('Error setting targeting for environment:', error);

--- a/packages/app/src/server/services/cache.ts
+++ b/packages/app/src/server/services/cache.ts
@@ -1,0 +1,8 @@
+import { CacheService } from '@llmops/core';
+
+export const cacheService = new CacheService({
+  backend: 'memory',
+  maxSize: 1000,
+  cleanupInterval: 60 * 1000, // 1 minute
+  defaultTtl: 5 * 60 * 1000, // 5 minutes
+});


### PR DESCRIPTION
Introduce CacheService (in-memory, 5m TTL) and use it to cache variant and provider DB lookups; clear/delete cache on provider and targeting updates. Add _ralph to .gitignore.