### PR TITLE
Initialize auth client only for API routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@
 [![npm version](https://img.shields.io/npm/v/@llmops/sdk.svg?style=flat&colorA=000000&colorB=000000)](https://www.npmjs.com/package/@llmops/sdk?primary=neutral&gray=neutral&theme=dark)
 [![GitHub stars](https://img.shields.io/github/stars/llmops-build/llmops?style=flat&colorA=000000&colorB=000000)](https://github.com/llmops-build/llmops/stargazers)
 
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/a_45hq?referralCode=RgsWj1&utm_medium=integration&utm_source=template&utm_campaign=generic)
+
 ## About the Project
 
 LLMOps is an open-source, pluggable toolkit designed for TypeScript teams to streamline LLM operations with a focus on developer experience. It provides a comprehensive solution for integrating, managing, and monitoring Large Language Model providers in your applications.

--- a/packages/core/src/auth/get-auth-client-options.ts
+++ b/packages/core/src/auth/get-auth-client-options.ts
@@ -17,6 +17,14 @@ export interface AuthClientOptions {
    * Use this to set up workspace settings like superAdminId.
    */
   onUserCreated?: (userId: string) => Promise<void>;
+  /**
+   * Base URL for the application (used for auth redirects and origin validation)
+   */
+  baseURL?: string;
+  /**
+   * Additional trusted origins for CORS (e.g., production domains)
+   */
+  trustedOrigins?: string[];
 }
 
 /**
@@ -27,10 +35,12 @@ export interface AuthClientOptions {
 export const getAuthClientOptions = (
   options: AuthClientOptions
 ): BetterAuthOptions => {
-  const { database, onUserCreated } = options;
+  const { database, onUserCreated, baseURL, trustedOrigins } = options;
 
   return {
     database,
+    baseURL,
+    trustedOrigins,
     emailAndPassword: {
       enabled: true,
     },


### PR DESCRIPTION
Derive base URL from the incoming request and pass baseURL and trustedOrigins to Better Auth for origin validation. Extend AuthClientOptions with baseURL and trustedOrigins and propagate them to getAuthClientOptions. Add a "Deploy on Railway" badge to README.