### PR TITLE
Revamp variant form UI with collapsible message blocks

### DIFF
--- a/packages/app/src/client/components/ui/components/collapsible/collapsible.css.ts
+++ b/packages/app/src/client/components/ui/components/collapsible/collapsible.css.ts
@@ -1,0 +1,75 @@
+import { colors, spacing } from '../../tokens';
+import { style, keyframes } from '@vanilla-extract/css';
+
+const slideDown = keyframes({
+  from: { height: '0' },
+  to: { height: 'var(--collapsible-content-height)' },
+});
+
+const slideUp = keyframes({
+  from: { height: 'var(--collapsible-content-height)' },
+  to: { height: '0' },
+});
+
+export const collapsibleRoot = style({
+  backgroundColor: colors.gray2,
+  borderRadius: spacing.sm,
+  border: `1px solid ${colors.gray4}`,
+  overflow: 'hidden',
+});
+
+export const collapsibleTrigger = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  width: '100%',
+  padding: `${spacing.sm} ${spacing.md}`,
+  backgroundColor: 'transparent',
+  border: 'none',
+  cursor: 'pointer',
+  color: colors.gray11,
+  fontSize: '0.875rem',
+  fontWeight: 500,
+  textAlign: 'left',
+  transition: 'background-color 150ms ease',
+  ':hover': {
+    backgroundColor: colors.gray3,
+  },
+  ':focus-visible': {
+    outline: `2px solid ${colors.accent9}`,
+    outlineOffset: '-2px',
+  },
+});
+
+export const collapsibleTriggerIcon = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  color: colors.gray9,
+  transition: 'transform 200ms ease',
+  selectors: {
+    '[data-panel-open] &': {
+      transform: 'rotate(180deg)',
+    },
+  },
+});
+
+export const collapsiblePanel = style({
+  overflow: 'hidden',
+  selectors: {
+    '&[data-starting-style]': {
+      height: '0',
+    },
+    '&[data-open]': {
+      animation: `${slideDown} 200ms ease-out`,
+    },
+    '&[data-ending-style]': {
+      animation: `${slideUp} 200ms ease-out`,
+    },
+  },
+});
+
+export const collapsibleContent = style({
+  padding: spacing.md,
+  paddingTop: spacing.none,
+});

--- a/packages/app/src/client/components/ui/components/collapsible/collapsible.tsx
+++ b/packages/app/src/client/components/ui/components/collapsible/collapsible.tsx
@@ -1,0 +1,75 @@
+import * as React from 'react';
+import { Collapsible as BaseCollapsible } from '@base-ui/react/collapsible';
+import clsx from 'clsx';
+import { ChevronDown } from 'lucide-react';
+import * as styles from './collapsible.css';
+
+export interface CollapsibleProps {
+  children: React.ReactNode;
+  open?: boolean;
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  className?: string;
+}
+
+export interface CollapsibleTriggerProps {
+  children: React.ReactNode;
+  className?: string;
+  showIcon?: boolean;
+}
+
+export interface CollapsibleContentProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function Collapsible({
+  children,
+  open,
+  defaultOpen = true,
+  onOpenChange,
+  className,
+}: CollapsibleProps) {
+  return (
+    <BaseCollapsible.Root
+      open={open}
+      defaultOpen={defaultOpen}
+      onOpenChange={onOpenChange}
+      className={clsx(styles.collapsibleRoot, className)}
+    >
+      {children}
+    </BaseCollapsible.Root>
+  );
+}
+
+export function CollapsibleTrigger({
+  children,
+  className,
+  showIcon = true,
+}: CollapsibleTriggerProps) {
+  return (
+    <BaseCollapsible.Trigger className={clsx(styles.collapsibleTrigger, className)}>
+      {children}
+      {showIcon && (
+        <span className={styles.collapsibleTriggerIcon}>
+          <ChevronDown size={16} />
+        </span>
+      )}
+    </BaseCollapsible.Trigger>
+  );
+}
+
+export function CollapsibleContent({
+  children,
+  className,
+}: CollapsibleContentProps) {
+  return (
+    <BaseCollapsible.Panel className={styles.collapsiblePanel}>
+      <div className={clsx(styles.collapsibleContent, className)}>
+        {children}
+      </div>
+    </BaseCollapsible.Panel>
+  );
+}
+
+export { BaseCollapsible };

--- a/packages/app/src/client/components/ui/components/collapsible/index.ts
+++ b/packages/app/src/client/components/ui/components/collapsible/index.ts
@@ -1,0 +1,11 @@
+export {
+  Collapsible,
+  CollapsibleTrigger,
+  CollapsibleContent,
+  BaseCollapsible,
+} from './collapsible';
+export type {
+  CollapsibleProps,
+  CollapsibleTriggerProps,
+  CollapsibleContentProps,
+} from './collapsible';

--- a/packages/app/src/client/components/ui/components/index.ts
+++ b/packages/app/src/client/components/ui/components/index.ts
@@ -69,3 +69,15 @@ export type { TooltipProps } from './tooltip';
 
 export { Input } from './input';
 export type { InputProps } from './input';
+
+export {
+  Collapsible,
+  CollapsibleTrigger,
+  CollapsibleContent,
+  BaseCollapsible,
+} from './collapsible';
+export type {
+  CollapsibleProps,
+  CollapsibleTriggerProps,
+  CollapsibleContentProps,
+} from './collapsible';

--- a/packages/app/src/client/hooks/queries/useVariantVersions.ts
+++ b/packages/app/src/client/hooks/queries/useVariantVersions.ts
@@ -28,7 +28,7 @@ export const variantVersionsQueryOptions = (variantId: string) =>
       return ('data' in result ? result.data : []) as VariantVersion[];
     },
     enabled: !!variantId,
-    staleTime: 1000 * 60 * 5, // 5 minutes
+    staleTime: 0, // Always refetch to ensure latest data
   });
 
 export const useVariantVersions = (variantId: string) => {

--- a/packages/app/src/client/routes/(app)/prompts/$id/_variants/-components/message-block.css.ts
+++ b/packages/app/src/client/routes/(app)/prompts/$id/_variants/-components/message-block.css.ts
@@ -1,0 +1,175 @@
+import { colors, spacing } from '@ui';
+import { style, globalStyle } from '@vanilla-extract/css';
+
+export const messageBlockContainer = style({
+  backgroundColor: colors.gray2,
+  borderRadius: spacing.sm,
+  border: `1px solid ${colors.gray4}`,
+  overflow: 'hidden',
+});
+
+export const messageBlockHeader = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  padding: `${spacing.xs} ${spacing.sm}`,
+  backgroundColor: colors.gray2,
+  borderBottom: `1px solid transparent`,
+  transition: 'border-color 150ms ease',
+  selectors: {
+    [`${messageBlockContainer}[data-open] &`]: {
+      borderBottom: `1px solid ${colors.gray4}`,
+    },
+  },
+});
+
+export const messageBlockHeaderLeft = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: spacing.xs,
+});
+
+export const messageBlockHeaderRight = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: spacing.xs,
+});
+
+export const roleSelector = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: spacing.xs,
+  padding: `${spacing.xs} ${spacing.sm}`,
+  backgroundColor: 'transparent',
+  border: 'none',
+  borderRadius: spacing.xs,
+  cursor: 'pointer',
+  color: colors.gray11,
+  fontSize: '0.8125rem',
+  fontWeight: 500,
+  transition: 'background-color 150ms ease',
+  ':hover': {
+    backgroundColor: colors.gray3,
+  },
+});
+
+export const roleSelectorIcon = style({
+  display: 'flex',
+  alignItems: 'center',
+  color: colors.gray9,
+});
+
+export const expandButton = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  padding: spacing.xs,
+  backgroundColor: 'transparent',
+  border: 'none',
+  borderRadius: spacing.xs,
+  cursor: 'pointer',
+  color: colors.gray9,
+  transition: 'background-color 150ms ease, color 150ms ease, transform 200ms ease',
+  ':hover': {
+    backgroundColor: colors.gray3,
+    color: colors.gray11,
+  },
+  selectors: {
+    '&[data-open="true"]': {
+      transform: 'rotate(180deg)',
+    },
+  },
+});
+
+export const deleteButton = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  padding: spacing.xs,
+  backgroundColor: 'transparent',
+  border: 'none',
+  borderRadius: spacing.xs,
+  cursor: 'pointer',
+  color: colors.gray9,
+  transition: 'background-color 150ms ease, color 150ms ease',
+  ':hover': {
+    backgroundColor: colors.error3,
+    color: colors.error11,
+  },
+});
+
+export const messageBlockPanel = style({
+  overflow: 'hidden',
+});
+
+export const messageBlockContent = style({
+  padding: spacing.none,
+});
+
+export const editorWrapper = style({
+  position: 'relative',
+});
+
+// Override editor styles for message block
+globalStyle(`${editorWrapper} > div`, {
+  borderRadius: '0',
+  border: 'none',
+  backgroundColor: 'transparent',
+});
+
+// Make the editor content editable have smaller min-height
+globalStyle(`${editorWrapper} [contenteditable]`, {
+  minHeight: '6rem',
+});
+
+// Role menu styles
+export const roleMenuPopup = style({
+  backgroundColor: colors.gray1,
+  border: `1px solid ${colors.gray4}`,
+  borderRadius: spacing.sm,
+  boxShadow: '0 4px 16px rgba(0, 0, 0, 0.12)',
+  padding: spacing.xs,
+  minWidth: '120px',
+  zIndex: 100,
+});
+
+export const roleMenuItem = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: spacing.sm,
+  padding: `${spacing.xs} ${spacing.sm}`,
+  borderRadius: spacing.xs,
+  cursor: 'pointer',
+  fontSize: '0.8125rem',
+  color: colors.gray11,
+  transition: 'background-color 150ms ease',
+  ':hover': {
+    backgroundColor: colors.gray3,
+  },
+  selectors: {
+    '&[data-selected="true"]': {
+      backgroundColor: colors.accent3,
+      color: colors.accent11,
+    },
+  },
+});
+
+export const roleMenuItemIcon = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  width: '16px',
+});
+
+// Role-specific colors
+export const roleSystem = style({
+  color: colors.accent11,
+});
+
+export const roleUser = style({
+  color: '#22c55e', // green
+});
+
+export const roleAssistant = style({
+  color: '#a855f7', // purple
+});

--- a/packages/app/src/client/routes/(app)/prompts/$id/_variants/-components/message-block.tsx
+++ b/packages/app/src/client/routes/(app)/prompts/$id/_variants/-components/message-block.tsx
@@ -1,0 +1,161 @@
+import { useState, useRef } from 'react';
+import { useWatch, type Control } from 'react-hook-form';
+import { Collapsible as BaseCollapsible } from '@base-ui/react/collapsible';
+import { Menu as BaseMenu } from '@base-ui/react';
+import { ChevronDown, Trash2, Check, Monitor, User, Bot } from 'lucide-react';
+import clsx from 'clsx';
+import MarkdownEditor from './editor';
+import * as styles from './message-block.css';
+
+export type MessageRole = 'system' | 'user' | 'assistant';
+
+export interface Message {
+  id: string;
+  role: MessageRole;
+  content: string;
+}
+
+interface MessageBlockProps {
+  message: Message;
+  onChange: (message: Message) => void;
+  onDelete: () => void;
+  canDelete?: boolean;
+  editorKey?: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  control?: Control<any>;
+  index?: number;
+}
+
+const roleConfig: Record<
+  MessageRole,
+  { label: string; icon: typeof Monitor; className: string }
+> = {
+  system: { label: 'System', icon: Monitor, className: styles.roleSystem },
+  user: { label: 'User', icon: User, className: styles.roleUser },
+  assistant: { label: 'Assistant', icon: Bot, className: styles.roleAssistant },
+};
+
+export function MessageBlock({
+  message: initialMessage,
+  onChange,
+  onDelete,
+  canDelete = true,
+  editorKey,
+  control,
+  index,
+}: MessageBlockProps) {
+  const [isOpen, setIsOpen] = useState(true);
+
+  // Watch this specific field for reactive updates (handles form.reset() correctly)
+  const watchedMessage =
+    control && index !== undefined
+      ? (useWatch({ control, name: `messages.${index}` }) as
+          | Message
+          | undefined)
+      : undefined;
+
+  // Use watched value if available, otherwise fall back to prop
+  const message = watchedMessage ?? initialMessage;
+
+  console.log(message.role);
+
+  const config = roleConfig[message.role];
+  const RoleIcon = config.icon;
+
+  // Use refs to get latest values without causing infinite re-renders
+  // (the functions only reference refs, so React Compiler can memoize them properly)
+  const messageRef = useRef(message);
+  const onChangeRef = useRef(onChange);
+  messageRef.current = message;
+  onChangeRef.current = onChange;
+
+  const handleRoleChange = (newRole: MessageRole) => {
+    if (newRole !== messageRef.current.role) {
+      onChangeRef.current({ ...messageRef.current, role: newRole });
+    }
+  };
+
+  const handleContentChange = (content: string) => {
+    // Only trigger update if content actually changed
+    // Lexical's OnChangePlugin fires on selection/focus changes too
+    if (content !== messageRef.current.content) {
+      onChangeRef.current({ ...messageRef.current, content });
+    }
+  };
+
+  return (
+    <BaseCollapsible.Root
+      open={isOpen}
+      onOpenChange={setIsOpen}
+      className={styles.messageBlockContainer}
+      data-open={isOpen || undefined}
+    >
+      <div className={styles.messageBlockHeader}>
+        <div className={styles.messageBlockHeaderLeft}>
+          <BaseMenu.Root>
+            <BaseMenu.Trigger className={styles.roleSelector}>
+              <RoleIcon size={14} className={config.className} />
+              <span className={config.className}>{config.label}</span>
+              <ChevronDown size={12} className={styles.roleSelectorIcon} />
+            </BaseMenu.Trigger>
+            <BaseMenu.Portal>
+              <BaseMenu.Positioner sideOffset={4} align="start">
+                <BaseMenu.Popup className={styles.roleMenuPopup}>
+                  {(Object.keys(roleConfig) as MessageRole[]).map((role) => {
+                    const roleInfo = roleConfig[role];
+                    const Icon = roleInfo.icon;
+                    const isSelected = message.role === role;
+                    return (
+                      <BaseMenu.Item
+                        key={role}
+                        className={styles.roleMenuItem}
+                        data-selected={isSelected || undefined}
+                        onClick={() => handleRoleChange(role)}
+                      >
+                        <span className={styles.roleMenuItemIcon}>
+                          {isSelected && <Check size={14} />}
+                        </span>
+                        <Icon size={14} className={roleInfo.className} />
+                        <span>{roleInfo.label}</span>
+                      </BaseMenu.Item>
+                    );
+                  })}
+                </BaseMenu.Popup>
+              </BaseMenu.Positioner>
+            </BaseMenu.Portal>
+          </BaseMenu.Root>
+        </div>
+        <div className={styles.messageBlockHeaderRight}>
+          {canDelete && (
+            <button
+              type="button"
+              className={styles.deleteButton}
+              onClick={onDelete}
+              title="Delete message"
+            >
+              <Trash2 size={14} />
+            </button>
+          )}
+          <BaseCollapsible.Trigger
+            className={styles.expandButton}
+            data-open={isOpen}
+          >
+            <ChevronDown size={16} />
+          </BaseCollapsible.Trigger>
+        </div>
+      </div>
+      <BaseCollapsible.Panel className={styles.messageBlockPanel}>
+        <div className={clsx(styles.messageBlockContent, styles.editorWrapper)}>
+          <MarkdownEditor
+            key={editorKey}
+            value={message.content}
+            onChange={handleContentChange}
+            placeholder={`Enter ${config.label.toLowerCase()} message...`}
+          />
+        </div>
+      </BaseCollapsible.Panel>
+    </BaseCollapsible.Root>
+  );
+}
+
+export default MessageBlock;

--- a/packages/app/src/client/routes/(app)/prompts/$id/_variants/-components/model-selector.tsx
+++ b/packages/app/src/client/routes/(app)/prompts/$id/_variants/-components/model-selector.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useRef, useState } from 'react';
+import { useWatch, type Control } from 'react-hook-form';
 import { Slider } from '@ui';
 import {
   Combobox as BaseCombobox,
@@ -45,8 +46,19 @@ export type ModelSettings = {
   presencePenalty?: number;
 };
 
+type ModelSelectorFormData = {
+  provider: string;
+  modelName: string;
+  temperature?: number;
+  maxTokens?: number;
+  topP?: number;
+  frequencyPenalty?: number;
+  presencePenalty?: number;
+};
+
 type ModelSelectorProps = {
-  value: ModelSettings;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  control: Control<any>;
   onChange: (settings: ModelSettings) => void;
 };
 
@@ -143,11 +155,27 @@ const ProvidersMenubarContent = ({
   );
 };
 
-const ModelSelector = ({ value, onChange }: ModelSelectorProps) => {
+const ModelSelector = ({ control, onChange }: ModelSelectorProps) => {
   const { data: providerGroups } = useModelsGroupedByProvider();
   const [inputValue, setInputValue] = useState('');
   const menubarRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
+
+  // Watch only model-related fields - this isolates re-renders to this component
+  const value = useWatch<ModelSelectorFormData>({
+    control,
+    name: ['provider', 'modelName', 'temperature', 'maxTokens', 'topP', 'frequencyPenalty', 'presencePenalty'],
+  }) as [string, string, number | undefined, number | undefined, number | undefined, number | undefined, number | undefined];
+
+  const currentSettings: ModelSettings = {
+    provider: value[0] || '',
+    modelName: value[1] || '',
+    temperature: value[2],
+    maxTokens: value[3],
+    topP: value[4],
+    frequencyPenalty: value[5],
+    presencePenalty: value[6],
+  };
 
   const handleInputValueChange = (newValue: string) => {
     const wasEmpty = !inputValue?.trim();
@@ -167,7 +195,7 @@ const ModelSelector = ({ value, onChange }: ModelSelectorProps) => {
     newValue: number | undefined
   ) => {
     const updatedSettings = {
-      ...value,
+      ...currentSettings,
       [key]: newValue,
     };
 
@@ -237,10 +265,10 @@ const ModelSelector = ({ value, onChange }: ModelSelectorProps) => {
       .filter((g): g is ProviderGroupWithModels => g !== null);
   }, [groupsWithProviderInfo, inputValue]);
 
-  // Derive selectedKey from value.provider and value.modelName
+  // Derive selectedKey from currentSettings.provider and currentSettings.modelName
   const selectedKey =
-    value.provider && value.modelName
-      ? `${value.provider}_${value.modelName}`
+    currentSettings.provider && currentSettings.modelName
+      ? `${currentSettings.provider}_${currentSettings.modelName}`
       : null;
 
   const selectedModel = selectedKey
@@ -257,7 +285,7 @@ const ModelSelector = ({ value, onChange }: ModelSelectorProps) => {
     if (item && 'value' in item) {
       justSelectedRef.current = true;
       onChange({
-        ...value,
+        ...currentSettings,
         provider: item.provider.id,
         modelName: item.value,
       });
@@ -268,7 +296,7 @@ const ModelSelector = ({ value, onChange }: ModelSelectorProps) => {
     } else if (!item && !justSelectedRef.current) {
       // Only clear if this isn't a spurious null after selection
       onChange({
-        ...value,
+        ...currentSettings,
         provider: '',
         modelName: '',
       });
@@ -435,7 +463,7 @@ const ModelSelector = ({ value, onChange }: ModelSelectorProps) => {
                       <input
                         type="number"
                         className={styles.paramsInput}
-                        value={value.maxTokens ?? ''}
+                        value={currentSettings.maxTokens ?? ''}
                         placeholder="Default"
                         min={1}
                         max={selectedModel?.limit?.output || undefined}
@@ -451,7 +479,7 @@ const ModelSelector = ({ value, onChange }: ModelSelectorProps) => {
                     {selectedModel?.temperature !== false && (
                       <Slider
                         label="Temperature"
-                        value={value.temperature ?? 1}
+                        value={currentSettings.temperature ?? 1}
                         min={0}
                         max={2}
                         step={0.1}
@@ -464,7 +492,7 @@ const ModelSelector = ({ value, onChange }: ModelSelectorProps) => {
 
                     <Slider
                       label="Top P"
-                      value={value.topP ?? 1}
+                      value={currentSettings.topP ?? 1}
                       min={0}
                       max={1}
                       step={0.05}
@@ -474,7 +502,7 @@ const ModelSelector = ({ value, onChange }: ModelSelectorProps) => {
 
                     <Slider
                       label="Frequency Penalty"
-                      value={value.frequencyPenalty ?? 0}
+                      value={currentSettings.frequencyPenalty ?? 0}
                       min={-2}
                       max={2}
                       step={0.1}
@@ -486,7 +514,7 @@ const ModelSelector = ({ value, onChange }: ModelSelectorProps) => {
 
                     <Slider
                       label="Presence Penalty"
-                      value={value.presencePenalty ?? 0}
+                      value={currentSettings.presencePenalty ?? 0}
                       min={-2}
                       max={2}
                       step={0.1}

--- a/packages/app/src/client/routes/(app)/prompts/$id/_variants/-components/variant-form.tsx
+++ b/packages/app/src/client/routes/(app)/prompts/$id/_variants/-components/variant-form.tsx
@@ -1,17 +1,21 @@
-import { useWatch, type UseFormReturn } from 'react-hook-form';
+import { useFieldArray, type UseFormReturn } from 'react-hook-form';
+import { Plus } from 'lucide-react';
 import {
   variantFormContainer,
   variantPropertyLabel,
   variantPropertyColumn,
+  messagesContainer,
+  addMessageButton,
+  actionsRow,
 } from './variants.css';
-import MarkdownEditor from './editor';
 import ModelSelector, { type ModelSettings } from './model-selector';
+import MessageBlock, { type Message, type MessageRole } from './message-block';
 
 export type VariantFormData = {
   variant_name: string;
   provider: string;
   modelName: string;
-  system_prompt: string;
+  messages: Message[];
   // Model parameters
   temperature?: number;
   maxTokens?: number;
@@ -25,95 +29,66 @@ type VariantFormProps = {
   editorKey?: string;
 };
 
+let messageIdCounter = 0;
+const generateMessageId = () => `msg_${Date.now()}_${++messageIdCounter}`;
+
 const VariantForm = ({ form, editorKey }: VariantFormProps) => {
   const { setValue, control } = form;
 
-  const selectedProvider = useWatch({
-    control: form.control,
-    name: 'provider',
-  });
-  const selectedModel = useWatch({
+  const { fields, append, remove } = useFieldArray({
     control,
-    name: 'modelName',
+    name: 'messages',
+    keyName: '_fieldId', // Use different name to avoid conflict with Message.id
   });
-  const systemPromptValue = useWatch({
-    control,
-    name: 'system_prompt',
-  });
-  const temperature = useWatch({
-    control,
-    name: 'temperature',
-  });
-  const maxTokens = useWatch({
-    control,
-    name: 'maxTokens',
-  });
-  const topP = useWatch({
-    control,
-    name: 'topP',
-  });
-  const frequencyPenalty = useWatch({
-    control,
-    name: 'frequencyPenalty',
-  });
-  const presencePenalty = useWatch({
-    control,
-    name: 'presencePenalty',
-  });
-
-  const modelSettings: ModelSettings = {
-    provider: selectedProvider || '',
-    modelName: selectedModel || '',
-    temperature,
-    maxTokens,
-    topP,
-    frequencyPenalty,
-    presencePenalty,
-  };
 
   const handleModelSettingsChange = (settings: ModelSettings) => {
-    if (settings.provider !== selectedProvider) {
-      setValue('provider', settings.provider, {
-        shouldValidate: true,
-        shouldDirty: true,
-      });
-    }
-    if (settings.modelName !== selectedModel) {
-      setValue('modelName', settings.modelName, {
-        shouldValidate: true,
-        shouldDirty: true,
-      });
-    }
-    if (settings.temperature !== temperature) {
-      setValue('temperature', settings.temperature, {
-        shouldValidate: true,
-        shouldDirty: true,
-      });
-    }
-    if (settings.maxTokens !== maxTokens) {
-      setValue('maxTokens', settings.maxTokens, {
-        shouldValidate: true,
-        shouldDirty: true,
-      });
-    }
-    if (settings.topP !== topP) {
-      setValue('topP', settings.topP, {
-        shouldValidate: true,
-        shouldDirty: true,
-      });
-    }
-    if (settings.frequencyPenalty !== frequencyPenalty) {
-      setValue('frequencyPenalty', settings.frequencyPenalty, {
-        shouldValidate: true,
-        shouldDirty: true,
-      });
-    }
-    if (settings.presencePenalty !== presencePenalty) {
-      setValue('presencePenalty', settings.presencePenalty, {
-        shouldValidate: true,
-        shouldDirty: true,
-      });
-    }
+    setValue('provider', settings.provider, {
+      shouldValidate: true,
+      shouldDirty: true,
+    });
+    setValue('modelName', settings.modelName, {
+      shouldValidate: true,
+      shouldDirty: true,
+    });
+    setValue('temperature', settings.temperature, {
+      shouldValidate: true,
+      shouldDirty: true,
+    });
+    setValue('maxTokens', settings.maxTokens, {
+      shouldValidate: true,
+      shouldDirty: true,
+    });
+    setValue('topP', settings.topP, {
+      shouldValidate: true,
+      shouldDirty: true,
+    });
+    setValue('frequencyPenalty', settings.frequencyPenalty, {
+      shouldValidate: true,
+      shouldDirty: true,
+    });
+    setValue('presencePenalty', settings.presencePenalty, {
+      shouldValidate: true,
+      shouldDirty: true,
+    });
+  };
+
+  const handleMessageChange = (index: number, message: Message) => {
+    // Use setValue instead of update() to avoid replacing the entire field
+    // which would cause the field ID to change and remount the editor
+    setValue(`messages.${index}.role`, message.role, { shouldDirty: true });
+    setValue(`messages.${index}.content`, message.content, { shouldDirty: true });
+  };
+
+  const handleAddMessage = (role: MessageRole = 'user') => {
+    append({
+      id: generateMessageId(),
+      role,
+      content: '',
+    });
+  };
+
+  const handleDeleteMessage = (index: number) => {
+    remove(index);
   };
 
   return (
@@ -122,27 +97,36 @@ const VariantForm = ({ form, editorKey }: VariantFormProps) => {
         <div className={variantPropertyLabel}>
           <span>Model</span>
         </div>
-        <ModelSelector value={modelSettings} onChange={handleModelSettingsChange} />
+        <ModelSelector
+          control={control}
+          onChange={handleModelSettingsChange}
+        />
       </div>
 
-      <div className={variantPropertyColumn}>
-        <div className={variantPropertyLabel}>
-          <span>System</span>
-          {/*<div className={markdownLabelInfo}>
-            <Markdown width={14} height={14} />
-            <span>Markdown Supported</span>
-          </div>*/}
-        </div>
-        <MarkdownEditor
-          key={editorKey}
-          value={systemPromptValue}
-          onChange={(value) =>
-            setValue('system_prompt', value, {
-              shouldValidate: true,
-              shouldDirty: true,
-            })
-          }
-        />
+      <div className={messagesContainer}>
+        {fields.map((field, index) => (
+          <MessageBlock
+            key={field._fieldId}
+            message={field}
+            onChange={(msg) => handleMessageChange(index, msg)}
+            onDelete={() => handleDeleteMessage(index)}
+            canDelete={fields.length > 1}
+            editorKey={`${editorKey}-${field._fieldId}`}
+            control={control}
+            index={index}
+          />
+        ))}
+      </div>
+
+      <div className={actionsRow}>
+        <button
+          type="button"
+          className={addMessageButton}
+          onClick={() => handleAddMessage('user')}
+        >
+          <Plus size={14} />
+          Message
+        </button>
       </div>
     </div>
   );

--- a/packages/app/src/client/routes/(app)/prompts/$id/_variants/-components/variants.css.ts
+++ b/packages/app/src/client/routes/(app)/prompts/$id/_variants/-components/variants.css.ts
@@ -17,6 +17,7 @@ export const variantHeader = style({
   borderBottom: `1px solid ${colors.gray4}`,
   left: '0',
   backgroundColor: colors.background,
+  zIndex: 10,
 });
 
 export const variantHeaderActions = style({
@@ -123,4 +124,45 @@ export const variantInlineInput = style([
 export const variantContentArea = style({
   marginTop: spacing.lg,
   padding: spacing.md,
+});
+
+// Messages section styles
+export const messagesContainer = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: spacing.sm,
+  marginTop: spacing.md,
+});
+
+export const addMessageButton = style([
+  sprinkles({
+    fontSize: 'sm',
+    borderRadius: 'xs',
+    paddingLeft: 'sm',
+    paddingRight: 'sm',
+  }),
+  {
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: spacing.xs,
+    height: '2rem',
+    backgroundColor: 'transparent',
+    border: `1px dashed ${colors.gray6}`,
+    cursor: 'pointer',
+    color: colors.gray11,
+    transition: 'all 150ms ease',
+    ':hover': {
+      backgroundColor: colors.gray2,
+      borderColor: colors.gray8,
+      color: colors.gray12,
+    },
+  },
+]);
+
+export const actionsRow = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: spacing.sm,
+  marginTop: spacing.sm,
+  flexWrap: 'wrap',
 });

--- a/packages/app/src/client/routes/(app)/prompts/$id/_variants/variants/$variant.tsx
+++ b/packages/app/src/client/routes/(app)/prompts/$id/_variants/variants/$variant.tsx
@@ -12,6 +12,7 @@ import {
 } from '../-components/variants.css';
 import { configTitleInput } from '../../../-components/configs.css';
 import VariantForm, { type VariantFormData } from '../-components/variant-form';
+import type { Message } from '../-components/message-block';
 import { useCreateVariant } from '@client/hooks/mutations/useCreateVariant';
 import { useCreateVariantVersion } from '@client/hooks/mutations/useCreateVariantVersion';
 import { useSetTargeting } from '@client/hooks/mutations/useSetTargeting';
@@ -89,7 +90,9 @@ function RouteComponent() {
       variant_name: '',
       provider: '',
       modelName: '',
-      system_prompt: '',
+      messages: [
+        { id: 'default-system', role: 'system', content: '' },
+      ],
       temperature: undefined,
       maxTokens: undefined,
       topP: undefined,
@@ -109,34 +112,15 @@ function RouteComponent() {
     ? [...versions].sort((a, b) => b.version - a.version)
     : [];
 
-  // Set initial selected version to the targeted version if available, otherwise latest
+  // Set initial selected version to the latest version
   useEffect(() => {
     if (versions && versions.length > 0 && !selectedVersionId) {
-      // Find the config variant for this variant
-      const configVariant = configVariants?.find(
-        (cv) => cv.variantId === variant
+      const latestVersion = versions.reduce((latest, current) =>
+        current.version > latest.version ? current : latest
       );
-
-      // Check if there's a targeting rule with a pinned version for this variant
-      const targetingRule = targetingRules?.find(
-        (rule) =>
-          configVariant &&
-          rule.configVariantId === configVariant.id &&
-          rule.variantVersionId
-      );
-
-      if (targetingRule?.variantVersionId) {
-        // Use the targeted (pinned) version
-        setSelectedVersionId(targetingRule.variantVersionId);
-      } else {
-        // Fall back to latest version
-        const latestVersion = versions.reduce((latest, current) =>
-          current.version > latest.version ? current : latest
-        );
-        setSelectedVersionId(latestVersion.id);
-      }
+      setSelectedVersionId(latestVersion.id);
     }
-  }, [versions, selectedVersionId, configVariants, targetingRules, variant]);
+  }, [versions, selectedVersionId]);
 
   useBlocker({
     shouldBlockFn: () => {
@@ -165,6 +149,25 @@ function RouteComponent() {
           ? (JSON.parse(selectedVersion.jsonData) as Record<string, unknown>)
           : (selectedVersion.jsonData as Record<string, unknown> | null);
 
+      // Convert old format (system_prompt) to new format (messages) for backwards compatibility
+      let messages: Message[];
+      if (jsonData?.messages && Array.isArray(jsonData.messages)) {
+        // New format: ensure each message has an id (we strip ids when saving)
+        messages = (
+          jsonData.messages as Array<{ role: Message['role']; content: string }>
+        ).map((msg, index) => ({
+          id: `msg-${selectedVersionId}-${index}`,
+          role: msg.role,
+          content: msg.content,
+        }));
+      } else {
+        // Old format: convert system_prompt to messages array
+        const systemPrompt = (jsonData?.system_prompt as string) || '';
+        messages = [
+          { id: `system-${selectedVersionId}`, role: 'system', content: systemPrompt },
+        ];
+      }
+
       form.reset(
         {
           variant_name: variantData.name || '',
@@ -172,7 +175,7 @@ function RouteComponent() {
           // Prefer model from jsonData, fallback to modelName column for backwards compatibility
           modelName:
             (jsonData?.model as string) || selectedVersion.modelName || '',
-          system_prompt: (jsonData?.system_prompt as string) || '',
+          messages,
           temperature: jsonData?.temperature as number | undefined,
           maxTokens: jsonData?.max_tokens as number | undefined,
           topP: jsonData?.top_p as number | undefined,
@@ -190,7 +193,8 @@ function RouteComponent() {
 
   const buildJsonData = (data: VariantFormData): Record<string, unknown> => {
     const jsonData: Record<string, unknown> = {
-      system_prompt: data.system_prompt,
+      // Store messages array in new format
+      messages: data.messages.map(({ role, content }) => ({ role, content })),
       // Store model in jsonData for future use (modelName column will be deprecated)
       model: data.modelName,
     };
@@ -290,6 +294,12 @@ function RouteComponent() {
           jsonData,
         });
 
+        // Update selected version to the newly created version
+        // This prevents the useEffect from resetting to old version data
+        if (versionResult) {
+          setSelectedVersionId(versionResult.id);
+        }
+
         // Deploy to environment if requested
         if (options.deployToEnvironment && options.environmentId) {
           // Find the config variant for this variant
@@ -308,9 +318,6 @@ function RouteComponent() {
           }
         }
       }
-
-      // Reset form
-      form.reset();
 
       // If deployed to environment, show success dialog
       if (deployedToEnvironment && options.environmentId) {

--- a/packages/app/src/client/routes/(app)/prompts/-components/configs.css.ts
+++ b/packages/app/src/client/routes/(app)/prompts/-components/configs.css.ts
@@ -18,6 +18,7 @@ export const headerStyles = style({
   left: '0',
   top: '0',
   backgroundColor: colors.background,
+  zIndex: 10,
 });
 
 export const configSlugStyles = style({

--- a/packages/app/src/server/handlers/genai/gatewayAdapter.ts
+++ b/packages/app/src/server/handlers/genai/gatewayAdapter.ts
@@ -140,7 +140,7 @@ const PROVIDER_MAP: Record<string, string> = {
 /**
  * Merges variant config with the request body for chat completions.
  * Variant config takes precedence over request body values.
- * If input variables are provided, they are used to render nunjucks templates in system_prompt.
+ * If input variables are provided, they are used to render nunjucks templates in messages.
  */
 function mergeChatCompletionBody(
   body: Record<string, unknown>,
@@ -148,11 +148,33 @@ function mergeChatCompletionBody(
   modelName: string,
   inputVariables?: Record<string, unknown>
 ): Record<string, unknown> {
-  // Build messages array: prepend system prompt from variant if present
+  // Build messages array: prepend variant messages if present
   const messages: Array<{ role: string; content: string }> = [];
 
-  if (variantConfig.system_prompt) {
-    // Render nunjucks template with input variables if provided
+  // Check for new messages array format first, fall back to old system_prompt format
+  if (variantConfig.messages && Array.isArray(variantConfig.messages)) {
+    // New format: use messages array from variant config
+    for (const msg of variantConfig.messages) {
+      let content = msg.content;
+      // Render nunjucks template with input variables if provided
+      if (inputVariables && Object.keys(inputVariables).length > 0) {
+        try {
+          content = renderTemplate(msg.content, inputVariables);
+        } catch (error) {
+          // If template rendering fails, use original content
+          console.warn(
+            'Template rendering failed, using original content:',
+            error
+          );
+        }
+      }
+      messages.push({
+        role: msg.role,
+        content,
+      });
+    }
+  } else if (variantConfig.system_prompt) {
+    // Old format: use system_prompt (backwards compatibility)
     let systemPromptContent = variantConfig.system_prompt;
     if (inputVariables && Object.keys(inputVariables).length > 0) {
       try {
@@ -175,7 +197,7 @@ function mergeChatCompletionBody(
     });
   }
 
-  // Append user's messages
+  // Append user's messages from request body
   if (Array.isArray(body.messages)) {
     messages.push(
       ...(body.messages as Array<{ role: string; content: string }>)

--- a/packages/core/src/schemas/openai.ts
+++ b/packages/core/src/schemas/openai.ts
@@ -330,6 +330,14 @@ export type ChatCompletionCreateParamsBase = z.infer<
 >;
 
 /**
+ * Schema for variant message - simplified message format for variant config
+ */
+const variantMessageSchema = z.object({
+  role: z.enum(['system', 'user', 'assistant']),
+  content: z.string(),
+});
+
+/**
  * Schema for variant jsonData - these are the parameters that can be
  * configured per variant to override the default chat completion settings.
  * This is a subset of ChatCompletionCreateParamsBase that makes sense to
@@ -337,7 +345,8 @@ export type ChatCompletionCreateParamsBase = z.infer<
  */
 export const variantJsonDataSchema = z.object({
   // LLMOps-specific fields
-  system_prompt: z.string().optional(),
+  system_prompt: z.string().optional(), // Deprecated: use messages instead
+  messages: z.array(variantMessageSchema).optional(), // New: array of messages
 
   // OpenAI-compatible fields
   model: z.string().optional(),


### PR DESCRIPTION
## Summary
Revamped the variant form UI to support multiple messages with collapsible blocks and role selection (System, User, Assistant). Added support for messages array in variant configurations while maintaining backwards compatibility with the old system_prompt format.

## Changes
- Created Collapsible UI component with animations
- Created MessageBlock component with role selector dropdown
- Updated VariantForm to use messages array instead of single system_prompt
- Fixed data fetching to always show latest version instead of deployed version
- Updated gateway adapter to handle messages array in API requests
- Added z-index to sticky headers to prevent content overlap on scroll

## Test plan
- [ ] Load an existing variant and verify the latest version is displayed
- [ ] Create a new message and verify the role selector works correctly
- [ ] Switch roles and save - verify the new role persists after reload
- [ ] Test message editing in the collapsible editor
- [ ] Verify backwards compatibility with variants using old system_prompt format