### PR TITLE
Design: Redesign costs page with minimal layout

### DIFF
--- a/packages/app/src/client/routes/(app)/observability/-components/observability.css.ts
+++ b/packages/app/src/client/routes/(app)/observability/-components/observability.css.ts
@@ -478,3 +478,152 @@ export const chartTitle = style([
     fontWeight: 500,
   },
 ]);
+
+// Minimal cost metrics layout (no cards)
+export const costMetricsContainer = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: spacing.xl,
+});
+
+export const costHero = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: spacing.xs,
+  paddingBottom: spacing.lg,
+  borderBottom: `1px solid ${colors.gray3}`,
+});
+
+export const costHeroLabel = style([
+  sprinkles({
+    fontSize: 'xs',
+    fontFamily: 'mono',
+    color: 'gray9',
+  }),
+  {
+    letterSpacing: '0.05em',
+    textTransform: 'uppercase',
+  },
+]);
+
+export const costHeroValue = style([
+  sprinkles({
+    fontFamily: 'mono',
+    color: 'gray12',
+  }),
+  {
+    fontSize: '3rem',
+    fontWeight: 600,
+    letterSpacing: '-0.03em',
+    lineHeight: 1,
+    margin: 0,
+  },
+]);
+
+export const costMetricsRow = style({
+  display: 'flex',
+  gap: spacing.xl,
+  flexWrap: 'wrap',
+});
+
+export const costMetricItem = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: spacing.xs,
+  minWidth: '120px',
+});
+
+export const costMetricLabel = style([
+  sprinkles({
+    fontSize: 'xs',
+    fontFamily: 'mono',
+    color: 'gray9',
+  }),
+  {
+    display: 'flex',
+    alignItems: 'center',
+    gap: spacing.xs,
+    letterSpacing: '0.02em',
+  },
+]);
+
+export const costMetricValue = style([
+  sprinkles({
+    fontSize: 'lg',
+    fontFamily: 'mono',
+    color: 'gray12',
+  }),
+  {
+    fontWeight: 600,
+    margin: 0,
+    lineHeight: 1.2,
+  },
+]);
+
+export const costMetricSubvalue = style([
+  sprinkles({
+    fontSize: 'xs',
+    fontFamily: 'mono',
+    color: 'gray10',
+  }),
+]);
+
+export const costBreakdownContainer = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: spacing.md,
+  paddingTop: spacing.md,
+});
+
+export const costBreakdownLabel = style([
+  sprinkles({
+    fontSize: 'xs',
+    fontFamily: 'mono',
+    color: 'gray9',
+  }),
+  {
+    letterSpacing: '0.05em',
+    textTransform: 'uppercase',
+    marginBottom: spacing.xs,
+  },
+]);
+
+export const costBreakdownBarWrapper = style({
+  position: 'relative',
+  height: '32px',
+  borderRadius: spacing.xs,
+  overflow: 'hidden',
+  backgroundColor: colors.gray3,
+});
+
+export const costBreakdownLegend = style({
+  display: 'flex',
+  gap: spacing.lg,
+  marginTop: spacing.sm,
+});
+
+export const costBreakdownLegendItem = style([
+  sprinkles({
+    fontSize: 'xs',
+    fontFamily: 'mono',
+  }),
+  {
+    display: 'flex',
+    alignItems: 'center',
+    gap: spacing.xs,
+  },
+]);
+
+export const costBreakdownDot = style({
+  width: '8px',
+  height: '8px',
+  borderRadius: '50%',
+});
+
+export const costBreakdownDotInput = style({
+  backgroundColor: '#10b981',
+});
+
+export const costBreakdownDotOutput = style({
+  backgroundColor: '#f59e0b',
+});

--- a/packages/app/src/client/routes/(app)/observability/_observability/costs.tsx
+++ b/packages/app/src/client/routes/(app)/observability/_observability/costs.tsx
@@ -4,13 +4,25 @@ import { DollarSign, Loader2 } from 'lucide-react';
 import { useMemo } from 'react';
 import { useTotalCost } from '@client/hooks/queries/useAnalytics';
 import {
-  overviewGrid,
-  statsCard,
-  statsCardLabel,
-  statsCardValue,
-  statsCardSubvalue,
   emptyState,
   loadingSpinner,
+  costMetricsContainer,
+  costHero,
+  costHeroLabel,
+  costHeroValue,
+  costMetricsRow,
+  costMetricItem,
+  costMetricLabel,
+  costMetricValue,
+  costMetricSubvalue,
+  costBreakdownContainer,
+  costBreakdownLabel,
+  costBreakdownBarWrapper,
+  costBreakdownLegend,
+  costBreakdownLegendItem,
+  costBreakdownDot,
+  costBreakdownDotInput,
+  costBreakdownDotOutput,
 } from '../-components/observability.css';
 
 export const Route = createFileRoute(
@@ -75,34 +87,119 @@ function RouteComponent() {
     );
   }
 
+  // Calculate percentages for the breakdown bar
+  // Use Number() to coerce values since PostgreSQL may return strings
+  const inputCost = Number(totalCost?.totalInputCost) || 0;
+  const outputCost = Number(totalCost?.totalOutputCost) || 0;
+  const totalCostValue = inputCost + outputCost;
+  const inputPercentage =
+    totalCostValue > 0 ? (inputCost / totalCostValue) * 100 : 0;
+  const outputPercentage =
+    totalCostValue > 0 ? (outputCost / totalCostValue) * 100 : 0;
+
   return (
-    <div>
-      <div className={overviewGrid}>
-        <div className={statsCard}>
-          <span className={statsCardLabel}>Total Cost</span>
-          <p className={statsCardValue}>{totalCost?.totalCostFormatted}</p>
-        </div>
-        <div className={statsCard}>
-          <span className={statsCardLabel}>Input Cost</span>
-          <p className={statsCardValue}>{totalCost?.totalInputCostFormatted}</p>
-          <span className={statsCardSubvalue}>
+    <div className={costMetricsContainer}>
+      {/* Hero: Total Cost */}
+      <div className={costHero}>
+        <span className={costHeroLabel}>Total Cost</span>
+        <p className={costHeroValue}>{totalCost?.totalCostFormatted}</p>
+      </div>
+
+      {/* Secondary metrics row */}
+      <div className={costMetricsRow}>
+        <div className={costMetricItem}>
+          <span className={costMetricLabel}>
+            <span
+              className={`${costBreakdownDot} ${costBreakdownDotInput}`}
+              style={{ width: 6, height: 6 }}
+            />
+            Input
+          </span>
+          <p className={costMetricValue}>
+            {totalCost?.totalInputCostFormatted}
+          </p>
+          <span className={costMetricSubvalue}>
             {totalCost?.totalPromptTokens.toLocaleString()} tokens
           </span>
         </div>
-        <div className={statsCard}>
-          <span className={statsCardLabel}>Output Cost</span>
-          <p className={statsCardValue}>
+
+        <div className={costMetricItem}>
+          <span className={costMetricLabel}>
+            <span
+              className={`${costBreakdownDot} ${costBreakdownDotOutput}`}
+              style={{ width: 6, height: 6 }}
+            />
+            Output
+          </span>
+          <p className={costMetricValue}>
             {totalCost?.totalOutputCostFormatted}
           </p>
-          <span className={statsCardSubvalue}>
+          <span className={costMetricSubvalue}>
             {totalCost?.totalCompletionTokens.toLocaleString()} tokens
           </span>
         </div>
-        <div className={statsCard}>
-          <span className={statsCardLabel}>Requests</span>
-          <p className={statsCardValue}>
+
+        <div className={costMetricItem}>
+          <span className={costMetricLabel}>Requests</span>
+          <p className={costMetricValue}>
             {totalCost?.requestCount.toLocaleString()}
           </p>
+        </div>
+      </div>
+
+      {/* Cost breakdown visualization - CSS-based stacked bar */}
+      <div className={costBreakdownContainer}>
+        <span className={costBreakdownLabel}>Cost Distribution</span>
+        <div
+          className={costBreakdownBarWrapper}
+          title={`Input: ${totalCost?.totalInputCostFormatted} (${inputPercentage.toFixed(1)}%)\nOutput: ${totalCost?.totalOutputCostFormatted} (${outputPercentage.toFixed(1)}%)`}
+        >
+          <div
+            style={{
+              display: 'flex',
+              height: '100%',
+              width: '100%',
+            }}
+          >
+            <div
+              title={`Input: ${totalCost?.totalInputCostFormatted} (${inputPercentage.toFixed(1)}%)`}
+              style={{
+                width: `${inputPercentage}%`,
+                height: '100%',
+                backgroundColor: '#10b981',
+                borderRadius:
+                  outputPercentage === 0 ? '4px' : '4px 0 0 4px',
+                transition: 'width 0.3s ease',
+                cursor: 'default',
+              }}
+            />
+            <div
+              title={`Output: ${totalCost?.totalOutputCostFormatted} (${outputPercentage.toFixed(1)}%)`}
+              style={{
+                width: `${outputPercentage}%`,
+                height: '100%',
+                backgroundColor: '#f59e0b',
+                borderRadius:
+                  inputPercentage === 0 ? '4px' : '0 4px 4px 0',
+                transition: 'width 0.3s ease',
+                cursor: 'default',
+              }}
+            />
+          </div>
+        </div>
+        <div className={costBreakdownLegend}>
+          <div className={costBreakdownLegendItem}>
+            <span className={`${costBreakdownDot} ${costBreakdownDotInput}`} />
+            <span style={{ color: '#b4b4b4' }}>
+              Input: {totalCost?.totalInputCostFormatted} ({inputPercentage.toFixed(0)}%)
+            </span>
+          </div>
+          <div className={costBreakdownLegendItem}>
+            <span className={`${costBreakdownDot} ${costBreakdownDotOutput}`} />
+            <span style={{ color: '#b4b4b4' }}>
+              Output: {totalCost?.totalOutputCostFormatted} ({outputPercentage.toFixed(0)}%)
+            </span>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary

Redesigned the costs page to use a clean, minimal typography-focused layout instead of card-based containers. The new design emphasizes visual hierarchy through spacing and font sizes.

## Changes

- Hero total cost section with prominent 3rem monospace display
- Horizontal metrics row showing input cost, output cost, and request count
- CSS-based stacked bar visualization for cost distribution
- Native tooltips showing detailed breakdown on hover
- Complete removal of card borders and backgrounds

## Design Notes

Uses only CSS flexbox and styled divs—no recharts needed for the distribution bar. Values properly coerced from PostgreSQL string aggregates.