### PR TITLE
Fix DataLayer to use flat spread for backwards compatibility

### DIFF
--- a/packages/core/src/datalayer/create.ts
+++ b/packages/core/src/datalayer/create.ts
@@ -21,24 +21,25 @@ import { createWorkspaceSettingsDataLayer } from './workspaceSettings';
 
 /**
  * Create all datalayers from a Kysely database instance.
+ * Returns a flat object with all datalayer methods spread together.
  */
 export function createDataLayer(db: Kysely<Database>): DataLayer {
   return {
-    configs: createConfigDataLayer(db),
-    configVariants: createConfigVariantDataLayer(db),
-    datasets: createDatasetsDataLayer(db),
-    environments: createEnvironmentDataLayer(db),
-    environmentSecrets: createEnvironmentSecretDataLayer(db),
-    guardrailConfigs: createGuardrailConfigsDataLayer(db),
-    llmRequests: createLLMRequestsDataLayer(db),
-    playgrounds: createPlaygroundDataLayer(db),
-    playgroundResults: createPlaygroundResultsDataLayer(db),
-    playgroundRuns: createPlaygroundRunsDataLayer(db),
-    providerConfigs: createProviderConfigsDataLayer(db),
-    providerGuardrailOverrides: createProviderGuardrailOverridesDataLayer(db),
-    targetingRules: createTargetingRulesDataLayer(db),
-    variants: createVariantDataLayer(db),
-    variantVersions: createVariantVersionsDataLayer(db),
-    workspaceSettings: createWorkspaceSettingsDataLayer(db),
+    ...createConfigDataLayer(db),
+    ...createConfigVariantDataLayer(db),
+    ...createDatasetsDataLayer(db),
+    ...createEnvironmentDataLayer(db),
+    ...createEnvironmentSecretDataLayer(db),
+    ...createGuardrailConfigsDataLayer(db),
+    ...createLLMRequestsDataLayer(db),
+    ...createPlaygroundDataLayer(db),
+    ...createPlaygroundResultsDataLayer(db),
+    ...createPlaygroundRunsDataLayer(db),
+    ...createProviderConfigsDataLayer(db),
+    ...createProviderGuardrailOverridesDataLayer(db),
+    ...createTargetingRulesDataLayer(db),
+    ...createVariantDataLayer(db),
+    ...createVariantVersionsDataLayer(db),
+    ...createWorkspaceSettingsDataLayer(db),
   };
 }

--- a/packages/core/src/datalayer/interface.ts
+++ b/packages/core/src/datalayer/interface.ts
@@ -51,22 +51,20 @@ export type WorkspaceSettingsDataLayer = ReturnType<
   typeof createWorkspaceSettingsDataLayer
 >;
 
-// Combined interface
-export interface DataLayer {
-  configs: ConfigsDataLayer;
-  configVariants: ConfigVariantsDataLayer;
-  datasets: DatasetsDataLayer;
-  environments: EnvironmentsDataLayer;
-  environmentSecrets: EnvironmentSecretsDataLayer;
-  guardrailConfigs: GuardrailConfigsDataLayer;
-  llmRequests: LLMRequestsDataLayer;
-  playgrounds: PlaygroundsDataLayer;
-  playgroundResults: PlaygroundResultsDataLayer;
-  playgroundRuns: PlaygroundRunsDataLayer;
-  providerConfigs: ProviderConfigsDataLayer;
-  providerGuardrailOverrides: ProviderGuardrailOverridesDataLayer;
-  targetingRules: TargetingRulesDataLayer;
-  variants: VariantsDataLayer;
-  variantVersions: VariantVersionsDataLayer;
-  workspaceSettings: WorkspaceSettingsDataLayer;
-}
+// Combined flat interface (all methods spread together)
+export type DataLayer = ConfigsDataLayer &
+  ConfigVariantsDataLayer &
+  DatasetsDataLayer &
+  EnvironmentsDataLayer &
+  EnvironmentSecretsDataLayer &
+  GuardrailConfigsDataLayer &
+  LLMRequestsDataLayer &
+  PlaygroundsDataLayer &
+  PlaygroundResultsDataLayer &
+  PlaygroundRunsDataLayer &
+  ProviderConfigsDataLayer &
+  ProviderGuardrailOverridesDataLayer &
+  TargetingRulesDataLayer &
+  VariantsDataLayer &
+  VariantVersionsDataLayer &
+  WorkspaceSettingsDataLayer;


### PR DESCRIPTION
## Summary
- Changed `createDataLayer` to spread all datalayer methods flat instead of namespacing them
- Updated `DataLayer` type to be an intersection of all individual datalayer types
- Maintains backwards compatibility with existing code that calls methods like `db.isSetupComplete()` directly

## Test plan
- [x] TypeScript compiles without errors
- [x] Existing API usage (`db.methodName()`) works unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)