### PR TITLE
Fix curl builder link overflow

### DIFF
--- a/packages/app/src/client/routes/(app)/gateway/-components/curl-builder.css.ts
+++ b/packages/app/src/client/routes/(app)/gateway/-components/curl-builder.css.ts
@@ -73,8 +73,9 @@ export const codeElement = style({
 
 export const codeLine = style({
   display: 'block',
-  whiteSpace: 'pre',
-  height: '2.2rem',
+  whiteSpace: 'pre-wrap',
+  wordBreak: 'break-all',
+  minHeight: '2.2rem',
   lineHeight: '2.2rem',
   borderTop: `1px dashed ${colors.gray4}`,
 });


### PR DESCRIPTION
Allow the long base URL to wrap within the code block by changing whiteSpace to pre-wrap and adding word-break: break-all. Also change height to minHeight to accommodate wrapped content.