### PR TITLE
Fix cost legend layout to display items vertically

### DIFF
--- a/packages/app/src/client/routes/(app)/observability/-components/observability.css.ts
+++ b/packages/app/src/client/routes/(app)/observability/-components/observability.css.ts
@@ -603,7 +603,8 @@ export const costBreakdownBarWrapper = style({
 
 export const costBreakdownLegend = style({
   display: 'flex',
-  gap: spacing.lg,
+  flexDirection: 'column',
+  gap: spacing.sm,
   marginTop: spacing.sm,
 });
 


### PR DESCRIPTION
## Summary
Changed costBreakdownLegend to use flex-direction: column so each legend item appears on a separate line for better readability.

## Test plan
- [ ] Review the cost distribution legend layout on the observability costs page
- [ ] Verify legend items are stacked vertically instead of horizontally