### PR TITLE
Add OpenRouter Responses API support

### DIFF
--- a/packages/gateway/src/providers/openrouter/api.ts
+++ b/packages/gateway/src/providers/openrouter/api.ts
@@ -10,10 +10,18 @@ const OpenrouterAPIConfig: ProviderAPIConfig = {
       'X-Title': POWERED_BY,
     };
   },
-  getEndpoint: ({ fn }) => {
+  getEndpoint: ({ fn, gatewayRequestURL }) => {
     switch (fn) {
       case 'chatComplete':
         return '/v1/chat/completions';
+      case 'createModelResponse':
+        return '/v1/responses';
+      case 'getModelResponse':
+      case 'deleteModelResponse':
+      case 'listResponseInputItems': {
+        const basePath = gatewayRequestURL.split('/v1')?.[1];
+        return basePath;
+      }
       default:
         return '';
     }

--- a/packages/gateway/src/providers/openrouter/createModelResponse.ts
+++ b/packages/gateway/src/providers/openrouter/createModelResponse.ts
@@ -1,0 +1,38 @@
+import { ProviderConfig } from '../types';
+import { createModelResponseParams } from '../open-ai-base';
+
+// OpenRouter-specific extra parameters for the Responses API
+// that extend the base OpenAI Responses API config.
+const openrouterExtraParams: ProviderConfig = {
+  provider: {
+    param: 'provider',
+    required: false,
+  },
+  plugins: {
+    param: 'plugins',
+    required: false,
+  },
+  top_k: {
+    param: 'top_k',
+    required: false,
+  },
+  frequency_penalty: {
+    param: 'frequency_penalty',
+    required: false,
+  },
+  presence_penalty: {
+    param: 'presence_penalty',
+    required: false,
+  },
+  session_id: {
+    param: 'session_id',
+    required: false,
+  },
+  trace: {
+    param: 'trace',
+    required: false,
+  },
+};
+
+export const OpenrouterCreateModelResponseConfig: ProviderConfig =
+  createModelResponseParams([], {}, openrouterExtraParams);

--- a/packages/gateway/src/providers/openrouter/index.ts
+++ b/packages/gateway/src/providers/openrouter/index.ts
@@ -5,13 +5,29 @@ import {
   OpenrouterChatCompleteResponseTransform,
   OpenrouterChatCompleteStreamChunkTransform,
 } from './chatComplete';
+import { OpenrouterCreateModelResponseConfig } from './createModelResponse';
+import {
+  OpenAICreateModelResponseTransformer,
+  OpenAIGetModelResponseTransformer,
+  OpenAIDeleteModelResponseTransformer,
+  OpenAIListInputItemsResponseTransformer,
+} from '../open-ai-base';
+import { OPENROUTER } from '../../globals';
 
 const OpenrouterConfig: ProviderConfigs = {
   chatComplete: OpenrouterChatCompleteConfig,
   api: OpenrouterAPIConfig,
+  createModelResponse: OpenrouterCreateModelResponseConfig,
+  getModelResponse: {},
+  deleteModelResponse: {},
+  listModelsResponse: {},
   responseTransforms: {
     chatComplete: OpenrouterChatCompleteResponseTransform,
     'stream-chatComplete': OpenrouterChatCompleteStreamChunkTransform,
+    createModelResponse: OpenAICreateModelResponseTransformer(OPENROUTER),
+    getModelResponse: OpenAIGetModelResponseTransformer(OPENROUTER),
+    deleteModelResponse: OpenAIDeleteModelResponseTransformer(OPENROUTER),
+    listModelsResponse: OpenAIListInputItemsResponseTransformer(OPENROUTER),
   },
 };
 


### PR DESCRIPTION
## Summary
Implements support for OpenRouter's Responses API endpoints (create, retrieve, delete, list input items) in the gateway provider system. Adds OpenRouter-specific parameters like provider routing, plugins, sampling options, and tracing metadata. Reuses existing OpenAI response transformers for seamless streaming and non-streaming support.

## Changes
- New `createModelResponse.ts` file with OpenRouter-specific Responses API config
- Extended `api.ts` with endpoint mappings for all four Responses API routes
- Updated `index.ts` to register configs and transformers for the Responses API

## Test plan
- Build verification successful (no type errors, clean compilation)
- Parameter transformation validated through config inheritance
- Response transformation handled by existing OpenAI transformers