### PR TITLE
feat: implement OpenRouter embeddings API support

### DIFF
--- a/packages/gateway/src/providers/openrouter/api.ts
+++ b/packages/gateway/src/providers/openrouter/api.ts
@@ -14,6 +14,8 @@ const OpenrouterAPIConfig: ProviderAPIConfig = {
     switch (fn) {
       case 'chatComplete':
         return '/v1/chat/completions';
+      case 'embed':
+        return '/v1/embeddings';
       case 'createModelResponse':
         return '/v1/responses';
       case 'getModelResponse':

--- a/packages/gateway/src/providers/openrouter/embed.ts
+++ b/packages/gateway/src/providers/openrouter/embed.ts
@@ -1,0 +1,50 @@
+import { OPENROUTER } from '../../globals';
+import { EmbedResponse } from '../../types/embedRequestBody';
+import { ErrorResponse, ProviderConfig } from '../types';
+import { embedParams } from '../open-ai-base';
+import {
+  generateErrorResponse,
+  generateInvalidProviderResponseError,
+} from '../utils';
+import { OpenrouterErrorResponse } from './chatComplete';
+
+const openrouterExtraParams: ProviderConfig = {
+  input_type: {
+    param: 'input_type',
+  },
+  provider: {
+    param: 'provider',
+  },
+};
+
+export const OpenrouterEmbedConfig: ProviderConfig = embedParams(
+  [],
+  {},
+  openrouterExtraParams
+);
+
+export const OpenrouterEmbedResponseTransform: (
+  response: EmbedResponse | OpenrouterErrorResponse,
+  responseStatus: number
+) => EmbedResponse | ErrorResponse = (response, responseStatus) => {
+  if ('message' in response && responseStatus !== 200) {
+    return generateErrorResponse(
+      {
+        message: response.message,
+        type: response.type,
+        param: response.param,
+        code: response.code,
+      },
+      OPENROUTER
+    );
+  }
+
+  if ('data' in response) {
+    return {
+      ...response,
+      provider: OPENROUTER,
+    };
+  }
+
+  return generateInvalidProviderResponseError(response, OPENROUTER);
+};

--- a/packages/gateway/src/providers/openrouter/index.ts
+++ b/packages/gateway/src/providers/openrouter/index.ts
@@ -7,6 +7,10 @@ import {
 } from './chatComplete';
 import { OpenrouterCreateModelResponseConfig } from './createModelResponse';
 import {
+  OpenrouterEmbedConfig,
+  OpenrouterEmbedResponseTransform,
+} from './embed';
+import {
   OpenAICreateModelResponseTransformer,
   OpenAIGetModelResponseTransformer,
   OpenAIDeleteModelResponseTransformer,
@@ -16,6 +20,7 @@ import { OPENROUTER } from '../../globals';
 
 const OpenrouterConfig: ProviderConfigs = {
   chatComplete: OpenrouterChatCompleteConfig,
+  embed: OpenrouterEmbedConfig,
   api: OpenrouterAPIConfig,
   createModelResponse: OpenrouterCreateModelResponseConfig,
   getModelResponse: {},
@@ -24,6 +29,7 @@ const OpenrouterConfig: ProviderConfigs = {
   responseTransforms: {
     chatComplete: OpenrouterChatCompleteResponseTransform,
     'stream-chatComplete': OpenrouterChatCompleteStreamChunkTransform,
+    embed: OpenrouterEmbedResponseTransform,
     createModelResponse: OpenAICreateModelResponseTransformer(OPENROUTER),
     getModelResponse: OpenAIGetModelResponseTransformer(OPENROUTER),
     deleteModelResponse: OpenAIDeleteModelResponseTransformer(OPENROUTER),


### PR DESCRIPTION
## Summary

Add embeddings endpoint support to OpenRouter provider. Implementation includes:
- New `embed.ts` with OpenAI-compatible parameter config and response transforms
- OpenRouter-specific extra params: `input_type` and `provider` (routing preferences)
- Error handling matching OpenRouter's error response format
- API endpoint registration (`/v1/embeddings`)

## Test plan

- Verify embed requests work with OpenRouter models that support embeddings
- Test parameter passing: `model`, `input`, `encoding_format`, `dimensions`, `user`, `input_type`, `provider`
- Verify error responses are properly transformed