### PR TITLE
Span annotations for human feedback

### DIFF
--- a/packages/app/src/client/hooks/mutations/useCreateSpanAnnotation.ts
+++ b/packages/app/src/client/hooks/mutations/useCreateSpanAnnotation.ts
@@ -1,0 +1,32 @@
+import { hc } from '@client/lib/hc';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { getSpanAnnotationsQueryKey } from '../queries/useSpanAnnotations';
+
+export const useCreateSpanAnnotation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (data: {
+      traceId: string;
+      spanId: string;
+      type: 'score' | 'label' | 'comment';
+      value: Record<string, unknown>;
+    }) => {
+      const response = await hc.v1.traces[':traceId'].spans[':spanId']
+        .annotations.$post({
+          param: { traceId: data.traceId, spanId: data.spanId },
+          json: { type: data.type, value: data.value },
+        });
+      const result = await response.json();
+      return 'data' in result ? result.data : undefined;
+    },
+    onSuccess: async (_, variables) => {
+      await queryClient.invalidateQueries({
+        queryKey: getSpanAnnotationsQueryKey(
+          variables.traceId,
+          variables.spanId
+        ),
+      });
+    },
+  });
+};

--- a/packages/app/src/client/hooks/mutations/useDeleteSpanAnnotation.ts
+++ b/packages/app/src/client/hooks/mutations/useDeleteSpanAnnotation.ts
@@ -1,0 +1,34 @@
+import { hc } from '@client/lib/hc';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { getSpanAnnotationsQueryKey } from '../queries/useSpanAnnotations';
+
+export const useDeleteSpanAnnotation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (data: {
+      traceId: string;
+      spanId: string;
+      annotationId: string;
+    }) => {
+      const response = await hc.v1.traces[':traceId'].spans[':spanId']
+        .annotations[':annotationId'].$delete({
+          param: {
+            traceId: data.traceId,
+            spanId: data.spanId,
+            annotationId: data.annotationId,
+          },
+        });
+      const result = await response.json();
+      return 'data' in result ? result.data : undefined;
+    },
+    onSuccess: async (_, variables) => {
+      await queryClient.invalidateQueries({
+        queryKey: getSpanAnnotationsQueryKey(
+          variables.traceId,
+          variables.spanId
+        ),
+      });
+    },
+  });
+};

--- a/packages/app/src/client/hooks/queries/useSpanAnnotations.ts
+++ b/packages/app/src/client/hooks/queries/useSpanAnnotations.ts
@@ -1,0 +1,32 @@
+import { hc } from '@client/lib/hc';
+import { useQuery } from '@tanstack/react-query';
+
+export type SpanAnnotationRow = {
+  id: string;
+  traceId: string;
+  spanId: string;
+  type: 'score' | 'label' | 'comment';
+  value: Record<string, unknown>;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export const getSpanAnnotationsQueryKey = (
+  traceId: string,
+  spanId: string
+) => ['span-annotations', traceId, spanId];
+
+export const useSpanAnnotations = (traceId: string, spanId: string) => {
+  return useQuery({
+    queryKey: getSpanAnnotationsQueryKey(traceId, spanId),
+    queryFn: async () => {
+      const response = await hc.v1.traces[':traceId'].spans[':spanId']
+        .annotations.$get({
+          param: { traceId, spanId },
+        });
+      const result = await response.json();
+      return ('data' in result ? result.data : []) as SpanAnnotationRow[];
+    },
+    enabled: !!traceId && !!spanId,
+  });
+};

--- a/packages/app/src/client/routes/(app)/observability/-components/trace-detail.css.ts
+++ b/packages/app/src/client/routes/(app)/observability/-components/trace-detail.css.ts
@@ -391,3 +391,104 @@ export const loadingContainer = style({
   justifyContent: 'center',
   height: '100%',
 });
+
+// Annotations
+export const annotationsContainer = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: spacing.xs,
+  margin: `${spacing.xs} 0 ${spacing.sm}`,
+});
+
+export const annotationItem = style([
+  sprinkles({
+    fontFamily: 'mono',
+    fontSize: 'xs',
+  }),
+  {
+    display: 'flex',
+    alignItems: 'center',
+    gap: spacing.sm,
+    padding: `${spacing.xs} ${spacing.sm}`,
+    backgroundColor: colors.gray2,
+    borderRadius: '4px',
+    border: `1px solid ${colors.gray4}`,
+  },
+]);
+
+export const annotationTypeBadge = style([
+  sprinkles({
+    fontFamily: 'mono',
+    fontSize: 'xs',
+    color: 'gray9',
+  }),
+  {
+    flexShrink: 0,
+    textTransform: 'uppercase',
+    letterSpacing: '0.03em',
+    minWidth: '56px',
+  },
+]);
+
+export const annotationContent = style([
+  sprinkles({ color: 'gray11' }),
+  {
+    flex: 1,
+    fontWeight: 500,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  },
+]);
+
+export const annotationDeleteBtn = style({
+  background: 'none',
+  border: 'none',
+  cursor: 'pointer',
+  padding: '2px',
+  color: colors.gray8,
+  flexShrink: 0,
+  ':hover': {
+    color: colors.error9,
+  },
+});
+
+export const annotationForm = style({
+  display: 'flex',
+  gap: spacing.xs,
+  margin: `${spacing.xs} 0`,
+});
+
+export const annotationSelect = style([
+  sprinkles({
+    fontFamily: 'mono',
+    fontSize: 'xs',
+    color: 'gray11',
+  }),
+  {
+    background: colors.gray2,
+    border: `1px solid ${colors.gray4}`,
+    borderRadius: '4px',
+    padding: `${spacing.xs} ${spacing.sm}`,
+    outline: 'none',
+  },
+]);
+
+export const annotationInput = style([
+  sprinkles({
+    fontFamily: 'mono',
+    fontSize: 'xs',
+    color: 'gray11',
+  }),
+  {
+    flex: 1,
+    background: colors.gray2,
+    border: `1px solid ${colors.gray4}`,
+    borderRadius: '4px',
+    padding: `${spacing.xs} ${spacing.sm}`,
+    outline: 'none',
+    '::placeholder': {
+      color: colors.gray8,
+    },
+  },
+]);

--- a/packages/app/src/client/routes/(app)/observability/-components/trace-detail.tsx
+++ b/packages/app/src/client/routes/(app)/observability/-components/trace-detail.tsx
@@ -2,12 +2,15 @@ import { useNavigate } from '@tanstack/react-router';
 import { Icon } from '@client/components/icons';
 import { X, ChevronRight, ChevronDown, Loader2 } from 'lucide-react';
 import { Button } from '@ui';
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useCallback } from 'react';
 import {
   useTraceDetail,
   type SpanRow,
   type SpanEventRow,
 } from '@client/hooks/queries/useTraces';
+import { useSpanAnnotations } from '@client/hooks/queries/useSpanAnnotations';
+import { useCreateSpanAnnotation } from '@client/hooks/mutations/useCreateSpanAnnotation';
+import { useDeleteSpanAnnotation } from '@client/hooks/mutations/useDeleteSpanAnnotation';
 import { statusBadge, statusSuccess, statusError } from './observability.css';
 import clsx from 'clsx';
 import { format } from 'date-fns';
@@ -55,6 +58,14 @@ import {
   eventName,
   emptyDetail,
   loadingContainer,
+  annotationsContainer,
+  annotationItem,
+  annotationTypeBadge,
+  annotationContent,
+  annotationDeleteBtn,
+  annotationForm,
+  annotationSelect,
+  annotationInput as annotationInputStyle,
 } from './trace-detail.css';
 
 type SpanNode = SpanRow & { children: SpanNode[]; depth: number };
@@ -273,13 +284,46 @@ function CollapsibleSection({
 function SpanDetailView({
   span,
   events,
+  traceId,
 }: {
   span: SpanRow;
   events: SpanEventRow[];
+  traceId: string;
 }) {
   const spanStatus = SPAN_STATUS_MAP[span.status] ?? 'unset';
   const spanKind = SPAN_KIND_MAP[span.kind] ?? 'internal';
   const spanEvents = events.filter((e) => e.spanId === span.spanId);
+
+  // Annotations
+  const { data: annotations = [] } = useSpanAnnotations(traceId, span.spanId);
+  const createAnnotation = useCreateSpanAnnotation();
+  const deleteAnnotation = useDeleteSpanAnnotation();
+  const [annotationType, setAnnotationType] = useState<'score' | 'label' | 'comment'>('comment');
+  const [annotationInputValue, setAnnotationInputValue] = useState('');
+
+  const handleAnnotationSubmit = useCallback(() => {
+    const trimmed = annotationInputValue.trim();
+    if (!trimmed) return;
+
+    let value: Record<string, unknown>;
+    if (annotationType === 'score') {
+      const num = Number(trimmed);
+      if (isNaN(num)) return;
+      value = { score: num };
+    } else if (annotationType === 'label') {
+      value = { label: trimmed };
+    } else {
+      value = { comment: trimmed };
+    }
+
+    createAnnotation.mutate({
+      traceId,
+      spanId: span.spanId,
+      type: annotationType,
+      value,
+    });
+    setAnnotationInputValue('');
+  }, [annotationInputValue, annotationType, traceId, span.spanId, createAnnotation]);
 
   const filteredAttributes = useMemo(() => {
     return Object.entries(span.attributes).filter(
@@ -406,6 +450,65 @@ function SpanDetailView({
           <pre className={jsonBlock}>{span.statusMessage}</pre>
         </CollapsibleSection>
       )}
+
+      {/* Annotations */}
+      <CollapsibleSection title={`Annotations (${annotations.length})`} defaultOpen>
+        {annotations.length > 0 && (
+          <div className={annotationsContainer}>
+            {annotations.map((ann) => (
+              <div className={annotationItem} key={ann.id}>
+                <span className={annotationTypeBadge}>{ann.type}</span>
+                <span className={annotationContent}>
+                  {ann.type === 'score' && `${(ann.value as Record<string, unknown>).name ?? 'Score'}: ${(ann.value as Record<string, unknown>).score}`}
+                  {ann.type === 'label' && String((ann.value as Record<string, unknown>).label)}
+                  {ann.type === 'comment' && String((ann.value as Record<string, unknown>).comment)}
+                </span>
+                <button
+                  type="button"
+                  className={annotationDeleteBtn}
+                  onClick={() =>
+                    deleteAnnotation.mutate({
+                      traceId,
+                      spanId: span.spanId,
+                      annotationId: ann.id,
+                    })
+                  }
+                >
+                  <Icon icon={X} size="xs" />
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+        <div className={annotationForm}>
+          <select
+            className={annotationSelect}
+            value={annotationType}
+            onChange={(e) => setAnnotationType(e.target.value as 'score' | 'label' | 'comment')}
+          >
+            <option value="comment">Comment</option>
+            <option value="label">Label</option>
+            <option value="score">Score</option>
+          </select>
+          <input
+            className={annotationInputStyle}
+            placeholder={
+              annotationType === 'score'
+                ? 'Score (e.g. 0-10)'
+                : annotationType === 'label'
+                  ? 'Label name'
+                  : 'Add a comment...'
+            }
+            value={annotationInputValue}
+            onChange={(e) => setAnnotationInputValue(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                handleAnnotationSubmit();
+              }
+            }}
+          />
+        </div>
+      </CollapsibleSection>
     </div>
   );
 }
@@ -556,7 +659,7 @@ export function TraceDetail({ traceId }: { traceId: string }) {
 
         {/* Selected span detail */}
         {selectedSpan && (
-          <SpanDetailView span={selectedSpan} events={events} />
+          <SpanDetailView span={selectedSpan} events={events} traceId={trace.traceId} />
         )}
       </div>
     </div>

--- a/packages/app/src/server/handlers/traces/index.ts
+++ b/packages/app/src/server/handlers/traces/index.ts
@@ -1,5 +1,9 @@
 import { zv } from '@server/lib/zv';
-import { internalServerError, successResponse } from '@shared/responses';
+import {
+  clientErrorResponse,
+  internalServerError,
+  successResponse,
+} from '@shared/responses';
 import { Hono } from 'hono';
 import z from 'zod';
 
@@ -33,6 +37,23 @@ interface DbWithTraces {
     endDate: Date;
     sessionId?: string;
     userId?: string;
+  }) => Promise<unknown | undefined>;
+  listSpanAnnotations: (params: {
+    spanId: string;
+  }) => Promise<unknown[]>;
+  createSpanAnnotation: (params: {
+    traceId: string;
+    spanId: string;
+    type: 'score' | 'label' | 'comment';
+    value: Record<string, unknown>;
+  }) => Promise<unknown | undefined>;
+  updateSpanAnnotation: (params: {
+    annotationId: string;
+    type?: 'score' | 'label' | 'comment';
+    value?: Record<string, unknown>;
+  }) => Promise<unknown | undefined>;
+  deleteSpanAnnotation: (params: {
+    annotationId: string;
   }) => Promise<unknown | undefined>;
 }
 
@@ -206,6 +227,171 @@ const app = new Hono()
         console.error('Error fetching trace stats:', error);
         return c.json(
           internalServerError('Failed to fetch trace stats', 500),
+          500
+        );
+      }
+    }
+  )
+
+  // ============ Span Annotations ============
+
+  /**
+   * GET /traces/:traceId/spans/:spanId/annotations
+   * List annotations for a span
+   */
+  .get(
+    '/:traceId/spans/:spanId/annotations',
+    zv(
+      'param',
+      z.object({
+        traceId: z.string(),
+        spanId: z.string(),
+      })
+    ),
+    async (c) => {
+      const db = c.get('db') as unknown as DbWithTraces;
+      const { spanId } = c.req.valid('param');
+
+      try {
+        const annotations = await db.listSpanAnnotations({ spanId });
+        return c.json(successResponse(annotations, 200));
+      } catch (error) {
+        console.error('Error fetching annotations:', error);
+        return c.json(
+          internalServerError('Failed to fetch annotations', 500),
+          500
+        );
+      }
+    }
+  )
+
+  /**
+   * POST /traces/:traceId/spans/:spanId/annotations
+   * Create an annotation on a span
+   */
+  .post(
+    '/:traceId/spans/:spanId/annotations',
+    zv(
+      'param',
+      z.object({
+        traceId: z.string(),
+        spanId: z.string(),
+      })
+    ),
+    zv(
+      'json',
+      z.object({
+        type: z.enum(['score', 'label', 'comment']),
+        value: z.record(z.string(), z.unknown()),
+      })
+    ),
+    async (c) => {
+      const db = c.get('db') as unknown as DbWithTraces;
+      const { traceId, spanId } = c.req.valid('param');
+      const body = c.req.valid('json');
+
+      try {
+        const annotation = await db.createSpanAnnotation({
+          traceId,
+          spanId,
+          ...body,
+        });
+        if (!annotation) {
+          return c.json(
+            internalServerError('Failed to create annotation', 500),
+            500
+          );
+        }
+        return c.json(successResponse(annotation, 200));
+      } catch (error) {
+        console.error('Error creating annotation:', error);
+        return c.json(
+          internalServerError('Failed to create annotation', 500),
+          500
+        );
+      }
+    }
+  )
+
+  /**
+   * PATCH /traces/:traceId/spans/:spanId/annotations/:annotationId
+   * Update an annotation
+   */
+  .patch(
+    '/:traceId/spans/:spanId/annotations/:annotationId',
+    zv(
+      'param',
+      z.object({
+        traceId: z.string(),
+        spanId: z.string(),
+        annotationId: z.string(),
+      })
+    ),
+    zv(
+      'json',
+      z.object({
+        type: z.enum(['score', 'label', 'comment']).optional(),
+        value: z.record(z.string(), z.unknown()).optional(),
+      })
+    ),
+    async (c) => {
+      const db = c.get('db') as unknown as DbWithTraces;
+      const { annotationId } = c.req.valid('param');
+      const body = c.req.valid('json');
+
+      try {
+        const annotation = await db.updateSpanAnnotation({
+          annotationId,
+          ...body,
+        });
+        if (!annotation) {
+          return c.json(
+            clientErrorResponse('Annotation not found', 404),
+            404
+          );
+        }
+        return c.json(successResponse(annotation, 200));
+      } catch (error) {
+        console.error('Error updating annotation:', error);
+        return c.json(
+          internalServerError('Failed to update annotation', 500),
+          500
+        );
+      }
+    }
+  )
+
+  /**
+   * DELETE /traces/:traceId/spans/:spanId/annotations/:annotationId
+   * Delete an annotation
+   */
+  .delete(
+    '/:traceId/spans/:spanId/annotations/:annotationId',
+    zv(
+      'param',
+      z.object({
+        traceId: z.string(),
+        spanId: z.string(),
+        annotationId: z.string(),
+      })
+    ),
+    async (c) => {
+      const db = c.get('db') as unknown as DbWithTraces;
+      const { annotationId } = c.req.valid('param');
+
+      try {
+        const annotation = await db.deleteSpanAnnotation({ annotationId });
+        if (!annotation) {
+          return c.json(
+            clientErrorResponse('Annotation not found', 404),
+            404
+          );
+        }
+        return c.json(successResponse(annotation, 200));
+      } catch (error) {
+        console.error('Error deleting annotation:', error);
+        return c.json(
+          internalServerError('Failed to delete annotation', 500),
           500
         );
       }

--- a/packages/core/src/datalayer/create.ts
+++ b/packages/core/src/datalayer/create.ts
@@ -18,6 +18,7 @@ import { createTargetingRulesDataLayer } from './targetingRules';
 import { createTracesDataLayer } from './traces';
 import { createVariantDataLayer } from './variants';
 import { createVariantVersionsDataLayer } from './variantVersions';
+import { createSpanAnnotationsDataLayer } from './spanAnnotations';
 import { createWorkspaceSettingsDataLayer } from './workspaceSettings';
 
 /**
@@ -42,6 +43,7 @@ export function createDataLayer(db: Kysely<Database>): DataLayer {
     ...createTracesDataLayer(db),
     ...createVariantDataLayer(db),
     ...createVariantVersionsDataLayer(db),
+    ...createSpanAnnotationsDataLayer(db),
     ...createWorkspaceSettingsDataLayer(db),
   };
 }

--- a/packages/core/src/datalayer/index.ts
+++ b/packages/core/src/datalayer/index.ts
@@ -17,6 +17,7 @@ export { createTracesDataLayer } from './traces';
 export type { TraceUpsert, SpanInsert, SpanEventInsert } from './traces';
 export { createVariantDataLayer } from './variants';
 export { createVariantVersionsDataLayer } from './variantVersions';
+export { createSpanAnnotationsDataLayer } from './spanAnnotations';
 export { createWorkspaceSettingsDataLayer } from './workspaceSettings';
 
 // New exports
@@ -39,5 +40,6 @@ export type {
   TracesDataLayer,
   VariantsDataLayer,
   VariantVersionsDataLayer,
+  SpanAnnotationsDataLayer,
   WorkspaceSettingsDataLayer,
 } from './interface';

--- a/packages/core/src/datalayer/interface.ts
+++ b/packages/core/src/datalayer/interface.ts
@@ -14,6 +14,7 @@ import type { createTargetingRulesDataLayer } from './targetingRules';
 import type { createVariantDataLayer } from './variants';
 import type { createVariantVersionsDataLayer } from './variantVersions';
 import type { createTracesDataLayer } from './traces';
+import type { createSpanAnnotationsDataLayer } from './spanAnnotations';
 import type { createWorkspaceSettingsDataLayer } from './workspaceSettings';
 
 // Infer types from existing implementations
@@ -49,6 +50,9 @@ export type VariantVersionsDataLayer = ReturnType<
   typeof createVariantVersionsDataLayer
 >;
 export type TracesDataLayer = ReturnType<typeof createTracesDataLayer>;
+export type SpanAnnotationsDataLayer = ReturnType<
+  typeof createSpanAnnotationsDataLayer
+>;
 export type WorkspaceSettingsDataLayer = ReturnType<
   typeof createWorkspaceSettingsDataLayer
 >;
@@ -70,4 +74,5 @@ export type DataLayer = ConfigsDataLayer &
   TracesDataLayer &
   VariantsDataLayer &
   VariantVersionsDataLayer &
+  SpanAnnotationsDataLayer &
   WorkspaceSettingsDataLayer;

--- a/packages/core/src/datalayer/spanAnnotations.ts
+++ b/packages/core/src/datalayer/spanAnnotations.ts
@@ -1,0 +1,110 @@
+import { LLMOpsError } from '@/error';
+import type { Database } from '@/schemas';
+import type { Kysely } from 'kysely';
+import { randomUUID } from 'node:crypto';
+import z from 'zod';
+
+const createAnnotation = z.object({
+  traceId: z.string(),
+  spanId: z.string(),
+  type: z.enum(['score', 'label', 'comment']),
+  value: z.record(z.string(), z.unknown()),
+});
+
+const updateAnnotation = z.object({
+  annotationId: z.string().uuid(),
+  type: z.enum(['score', 'label', 'comment']).optional(),
+  value: z.record(z.string(), z.unknown()).optional(),
+});
+
+const deleteAnnotation = z.object({
+  annotationId: z.string().uuid(),
+});
+
+const listAnnotationsBySpan = z.object({
+  spanId: z.string(),
+});
+
+export const createSpanAnnotationsDataLayer = (db: Kysely<Database>) => {
+  return {
+    createSpanAnnotation: async (
+      params: z.infer<typeof createAnnotation>
+    ) => {
+      const value = await createAnnotation.safeParseAsync(params);
+      if (!value.success) {
+        throw new LLMOpsError(`Invalid parameters: ${value.error.message}`);
+      }
+      const { traceId, spanId, type, value: annotationValue } = value.data;
+      const now = new Date().toISOString();
+
+      return db
+        .insertInto('span_annotations')
+        .values({
+          id: randomUUID(),
+          traceId,
+          spanId,
+          type,
+          value: JSON.stringify(annotationValue),
+          createdAt: now,
+          updatedAt: now,
+        })
+        .returningAll()
+        .executeTakeFirst();
+    },
+
+    updateSpanAnnotation: async (
+      params: z.infer<typeof updateAnnotation>
+    ) => {
+      const result = await updateAnnotation.safeParseAsync(params);
+      if (!result.success) {
+        throw new LLMOpsError(`Invalid parameters: ${result.error.message}`);
+      }
+      const { annotationId, type, value: annotationValue } = result.data;
+
+      const updateData: Record<string, unknown> = {
+        updatedAt: new Date().toISOString(),
+      };
+      if (type !== undefined) updateData.type = type;
+      if (annotationValue !== undefined)
+        updateData.value = JSON.stringify(annotationValue);
+
+      return db
+        .updateTable('span_annotations')
+        .set(updateData)
+        .where('id', '=', annotationId)
+        .returningAll()
+        .executeTakeFirst();
+    },
+
+    deleteSpanAnnotation: async (
+      params: z.infer<typeof deleteAnnotation>
+    ) => {
+      const result = await deleteAnnotation.safeParseAsync(params);
+      if (!result.success) {
+        throw new LLMOpsError(`Invalid parameters: ${result.error.message}`);
+      }
+
+      return db
+        .deleteFrom('span_annotations')
+        .where('id', '=', result.data.annotationId)
+        .returningAll()
+        .executeTakeFirst();
+    },
+
+    listSpanAnnotations: async (
+      params: z.infer<typeof listAnnotationsBySpan>
+    ) => {
+      const result = await listAnnotationsBySpan.safeParseAsync(params);
+      if (!result.success) {
+        throw new LLMOpsError(`Invalid parameters: ${result.error.message}`);
+      }
+
+      return db
+        .selectFrom('span_annotations')
+        .selectAll()
+        .where('spanId', '=', result.data.spanId)
+        .orderBy('createdAt', 'desc')
+        .execute();
+    },
+  };
+};

--- a/packages/core/src/db/schema.ts
+++ b/packages/core/src/db/schema.ts
@@ -336,6 +336,15 @@ export const spanEventsSchema = z.object({
   createdAt: z.date(),
 });
 
+// Span annotations table schema - human feedback on spans (scores, labels, comments)
+export const spanAnnotationsSchema = z.object({
+  ...baseSchema,
+  traceId: z.string(),
+  spanId: z.string(),
+  type: z.enum(['score', 'label', 'comment']),
+  value: z.record(z.string(), z.unknown()), // { score: 5 } | { label: "hallucination" } | { comment: "..." }
+});
+
 /**
  * Zod inferred types (for runtime validation)
  */
@@ -366,6 +375,7 @@ export type LLMRequest = z.infer<typeof llmRequestsSchema>;
 export type Trace = z.infer<typeof tracesSchema>;
 export type Span = z.infer<typeof spansSchema>;
 export type SpanEvent = z.infer<typeof spanEventsSchema>;
+export type SpanAnnotation = z.infer<typeof spanAnnotationsSchema>;
 
 /**
  * Kysely Table Interfaces
@@ -641,6 +651,14 @@ export interface SpanEventsTable {
   createdAt: ColumnType<Date, string | undefined, string | undefined>;
 }
 
+// Span annotations table - human feedback on spans
+export interface SpanAnnotationsTable extends BaseTable {
+  traceId: string;
+  spanId: string;
+  type: string;
+  value: ColumnType<Record<string, unknown>, string, string>;
+}
+
 /**
  * Main Kysely Database interface
  */
@@ -667,6 +685,7 @@ export interface Database {
   traces: TracesTable;
   spans: SpansTable;
   span_events: SpanEventsTable;
+  span_annotations: SpanAnnotationsTable;
 }
 
 /**
@@ -1159,6 +1178,19 @@ export const SCHEMA_METADATA = {
         createdAt: { type: 'timestamp', default: 'now()' },
       },
     },
+    span_annotations: {
+      order: 33,
+      schema: spanAnnotationsSchema,
+      fields: {
+        id: { type: 'uuid', primaryKey: true },
+        traceId: { type: 'text' },
+        spanId: { type: 'text' },
+        type: { type: 'text' },
+        value: { type: 'jsonb' },
+        createdAt: { type: 'timestamp', default: 'now()' },
+        updatedAt: { type: 'timestamp', default: 'now()', onUpdate: 'now()' },
+      },
+    },
   },
 } as const;
 
@@ -1189,4 +1221,5 @@ export const schemas = {
   traces: tracesSchema,
   spans: spansSchema,
   span_events: spanEventsSchema,
+  span_annotations: spanAnnotationsSchema,
 } as const;

--- a/packages/core/src/schemas/index.ts
+++ b/packages/core/src/schemas/index.ts
@@ -37,6 +37,7 @@ export type {
   DatasetRecord,
   DatasetVersionRecord,
   LLMRequest,
+  SpanAnnotation,
 } from '../db/schema';
 
 // Re-export Zod schemas for runtime validation


### PR DESCRIPTION
## Summary
Add support for annotating individual spans with structured human feedback (scores, labels, comments). This enables reviewers to provide quality signals on trace execution, supporting evaluation datasets, prompt iteration, and quality monitoring workflows.

## Changes
- **Database**: New `span_annotations` table with discriminated type (score/label/comment) and JSONB value
- **Datalayer**: CRUD methods with Zod validation
- **API**: 4 endpoints nested under traces (GET list, POST create, PATCH update, DELETE)
- **Client**: Query hook and mutation hooks with auto-invalidation
- **UI**: New "Annotations" collapsible section in SpanDetailView with list + inline form

## Testing
- Core package typechecks clean
- No annotation-specific lint errors
- Auto-migration creates table on startup
- Annotations work on any span via the detail view