### PR TITLE
feat: fix tag breakdown double-counting in cost distribution

### DIFF
--- a/packages/app/src/client/hooks/queries/useAnalytics.ts
+++ b/packages/app/src/client/hooks/queries/useAnalytics.ts
@@ -165,6 +165,7 @@ export const useDailyCosts = (dateRange: DateRange, enabled = true) => {
 export const useCostSummary = (
   params: DateRangeWithFilters & {
     groupBy?: CostSummaryGroupBy;
+    tagKeys?: string[];
   },
   enabled = true
 ) => {
@@ -181,6 +182,10 @@ export const useCostSummary = (
         ...(params.tags &&
           Object.keys(params.tags).length > 0 && {
             tags: JSON.stringify(params.tags),
+          }),
+        ...(params.tagKeys &&
+          params.tagKeys.length > 0 && {
+            tagKeys: JSON.stringify(params.tagKeys),
           }),
       };
       const response = await hc.v1.analytics.costs.summary.$get({

--- a/packages/app/src/client/routes/(app)/observability/-components/observability.css.ts
+++ b/packages/app/src/client/routes/(app)/observability/-components/observability.css.ts
@@ -734,3 +734,44 @@ export const costBreakdownSelectItemIndicator = style({
   display: 'inline-flex',
   alignItems: 'center',
 });
+
+export const tagKeyChipsContainer = style({
+  display: 'flex',
+  gap: '6px',
+  flexWrap: 'wrap',
+});
+
+export const tagKeyChip = style([
+  sprinkles({
+    fontSize: 'xs',
+    fontFamily: 'mono',
+    borderRadius: 'sm',
+  }),
+  {
+    display: 'inline-flex',
+    alignItems: 'center',
+    padding: `2px ${spacing.sm}`,
+    backgroundColor: colors.gray3,
+    color: colors.gray11,
+    border: `1px solid ${colors.gray6}`,
+    cursor: 'pointer',
+    height: '24px',
+    transition: 'all 0.15s ease',
+    ':hover': {
+      backgroundColor: colors.gray4,
+      borderColor: colors.gray7,
+    },
+  },
+]);
+
+export const tagKeyChipActive = style({
+  backgroundColor: colors.accent9,
+  color: 'white',
+  borderColor: colors.accent9,
+  selectors: {
+    [`${tagKeyChip}&:hover`]: {
+      backgroundColor: colors.accent10,
+      borderColor: colors.accent10,
+    },
+  },
+});

--- a/packages/app/src/client/routes/(app)/observability/_observability/costs.tsx
+++ b/packages/app/src/client/routes/(app)/observability/_observability/costs.tsx
@@ -2,10 +2,11 @@ import { Icon } from '@client/components/icons';
 import { createFileRoute, useSearch } from '@tanstack/react-router';
 import { Select } from '@base-ui/react/select';
 import { Check, ChevronDown, DollarSign, Loader2 } from 'lucide-react';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import {
   useTotalCost,
   useCostSummary,
+  useDistinctTags,
 } from '@client/hooks/queries/useAnalytics';
 import {
   emptyState,
@@ -34,6 +35,9 @@ import {
   costBreakdownSelectPopup,
   costBreakdownSelectOption,
   costBreakdownSelectItemIndicator,
+  tagKeyChipsContainer,
+  tagKeyChip,
+  tagKeyChipActive,
 } from '../-components/observability.css';
 
 export const Route = createFileRoute(
@@ -76,6 +80,7 @@ function formatCost(microdollars: number): string {
 function RouteComponent() {
   const search = useSearch({ from: '/(app)/observability' });
   const [breakdownBy, setBreakdownBy] = useState<BreakdownBy>('input-output');
+  const [selectedTagKeys, setSelectedTagKeys] = useState<string[]>([]);
   const dateRange = {
     startDate: search.from ?? '',
     endDate: search.to ?? '',
@@ -100,12 +105,38 @@ function RouteComponent() {
     tags: parsedTags,
   };
 
+  const { data: distinctTags } = useDistinctTags(breakdownBy === 'tags');
+  const availableTagKeys = useMemo(
+    () => [...new Set(distinctTags?.map((t) => t.key))],
+    [distinctTags]
+  );
+  // Stable string for dependency tracking to avoid re-running on same data
+  const availableTagKeysKey = availableTagKeys.join('\0');
+
+  // Auto-select first tag key when switching to tags breakdown
+  // Reset selection when switching back so it picks up any new keys
+  useEffect(() => {
+    if (breakdownBy === 'tags' && availableTagKeys.length > 0) {
+      setSelectedTagKeys((prev) =>
+        prev.length === 0 ? [availableTagKeys[0]] : prev
+      );
+    } else if (breakdownBy !== 'tags') {
+      setSelectedTagKeys([]);
+    }
+  }, [breakdownBy, availableTagKeysKey, availableTagKeys]);
+
   const { data: totalCost, isLoading } = useTotalCost(analyticsParams);
 
   const groupBy =
     breakdownBy !== 'input-output' ? breakdownBy : undefined;
   const { data: summaryData } = useCostSummary(
-    { ...analyticsParams, groupBy },
+    {
+      ...analyticsParams,
+      groupBy,
+      ...(breakdownBy === 'tags' && selectedTagKeys.length > 0
+        ? { tagKeys: selectedTagKeys }
+        : {}),
+    },
     breakdownBy !== 'input-output'
   );
 
@@ -149,13 +180,17 @@ function RouteComponent() {
       0
     );
     if (total === 0) return null;
+    const stripPrefix =
+      breakdownBy === 'tags' && selectedTagKeys.length === 1;
     return summaryData.map((item, i) => ({
-      label: item.groupKey,
+      label: stripPrefix
+        ? item.groupKey.replace(/^[^:]+:/, '')
+        : item.groupKey,
       cost: Number(item.totalCost),
       percentage: (Number(item.totalCost) / total) * 100,
       color: SEGMENT_COLORS[i % SEGMENT_COLORS.length],
     }));
-  }, [breakdownBy, summaryData]);
+  }, [breakdownBy, summaryData, selectedTagKeys]);
 
   return (
     <div className={costMetricsContainer}>
@@ -257,6 +292,31 @@ function RouteComponent() {
             </Select.Portal>
           </Select.Root>
         </div>
+
+        {breakdownBy === 'tags' && availableTagKeys.length > 0 && (
+          <div className={tagKeyChipsContainer}>
+            {availableTagKeys.map((key) => {
+              const isActive = selectedTagKeys.includes(key);
+              return (
+                <button
+                  key={key}
+                  type="button"
+                  className={`${tagKeyChip}${isActive ? ` ${tagKeyChipActive}` : ''}`}
+                  onClick={() => {
+                    if (isActive && selectedTagKeys.length === 1) return;
+                    setSelectedTagKeys((prev) =>
+                      isActive
+                        ? prev.filter((k) => k !== key)
+                        : [...prev, key]
+                    );
+                  }}
+                >
+                  {key}
+                </button>
+              );
+            })}
+          </div>
+        )}
 
         {breakdownBy === 'input-output' ? (
           <>

--- a/packages/app/src/server/handlers/analytics/index.test.ts
+++ b/packages/app/src/server/handlers/analytics/index.test.ts
@@ -1,0 +1,196 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+import analyticsApp from './index';
+
+/**
+ * Mock db that captures calls to getCostSummary
+ */
+function createMockDb(overrides: Record<string, unknown> = {}) {
+  return {
+    getTotalCost: vi.fn().mockResolvedValue(undefined),
+    getCostSummary: vi.fn().mockResolvedValue([]),
+    getRequestStats: vi.fn().mockResolvedValue(undefined),
+    listRequests: vi.fn().mockResolvedValue([]),
+    getRequestByRequestId: vi.fn().mockResolvedValue(undefined),
+    getCostByModel: vi.fn().mockResolvedValue([]),
+    getCostByProvider: vi.fn().mockResolvedValue([]),
+    getCostByConfig: vi.fn().mockResolvedValue([]),
+    getDailyCosts: vi.fn().mockResolvedValue([]),
+    getDistinctTags: vi.fn().mockResolvedValue([]),
+    ...overrides,
+  };
+}
+
+/**
+ * Creates a test Hono app that mounts the analytics handler
+ * with a mock db injected via middleware
+ */
+function createTestApp(mockDb: ReturnType<typeof createMockDb>) {
+  const app = new Hono();
+  app.use('*', async (c, next) => {
+    c.set('db', mockDb);
+    await next();
+  });
+  app.route('/analytics', analyticsApp);
+  return app;
+}
+
+const VALID_DATE_RANGE = 'startDate=2026-01-01&endDate=2026-01-31';
+
+describe('GET /analytics/costs/summary - tagKeys parameter', () => {
+  let mockDb: ReturnType<typeof createMockDb>;
+  let app: ReturnType<typeof createTestApp>;
+
+  beforeEach(() => {
+    mockDb = createMockDb();
+    app = createTestApp(mockDb);
+  });
+
+  test('passes parsed tagKeys array to getCostSummary when valid JSON provided', async () => {
+    const tagKeys = JSON.stringify(['orgId', 'teamName']);
+    const res = await app.request(
+      `/analytics/costs/summary?${VALID_DATE_RANGE}&groupBy=tags&tagKeys=${encodeURIComponent(tagKeys)}`
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockDb.getCostSummary).toHaveBeenCalledOnce();
+
+    const args = mockDb.getCostSummary.mock.calls[0][0];
+    expect(args.tagKeys).toEqual(['orgId', 'teamName']);
+    expect(args.groupBy).toBe('tags');
+  });
+
+  test('passes single tagKey correctly', async () => {
+    const tagKeys = JSON.stringify(['orgId']);
+    const res = await app.request(
+      `/analytics/costs/summary?${VALID_DATE_RANGE}&groupBy=tags&tagKeys=${encodeURIComponent(tagKeys)}`
+    );
+
+    expect(res.status).toBe(200);
+    const args = mockDb.getCostSummary.mock.calls[0][0];
+    expect(args.tagKeys).toEqual(['orgId']);
+  });
+
+  test('handles tagKeys with special characters (commas, spaces)', async () => {
+    const tagKeys = JSON.stringify(['org,Id', 'team name', 'key:with:colons']);
+    const res = await app.request(
+      `/analytics/costs/summary?${VALID_DATE_RANGE}&groupBy=tags&tagKeys=${encodeURIComponent(tagKeys)}`
+    );
+
+    expect(res.status).toBe(200);
+    const args = mockDb.getCostSummary.mock.calls[0][0];
+    expect(args.tagKeys).toEqual([
+      'org,Id',
+      'team name',
+      'key:with:colons',
+    ]);
+  });
+
+  test('does not pass tagKeys when parameter is omitted', async () => {
+    const res = await app.request(
+      `/analytics/costs/summary?${VALID_DATE_RANGE}&groupBy=model`
+    );
+
+    expect(res.status).toBe(200);
+    const args = mockDb.getCostSummary.mock.calls[0][0];
+    expect(args.tagKeys).toBeUndefined();
+  });
+
+  test('ignores invalid JSON for tagKeys', async () => {
+    const res = await app.request(
+      `/analytics/costs/summary?${VALID_DATE_RANGE}&groupBy=tags&tagKeys=not-valid-json`
+    );
+
+    expect(res.status).toBe(200);
+    const args = mockDb.getCostSummary.mock.calls[0][0];
+    expect(args.tagKeys).toBeUndefined();
+  });
+
+  test('filters out empty strings from tagKeys array', async () => {
+    const tagKeys = JSON.stringify(['orgId', '', 'teamName', '']);
+    const res = await app.request(
+      `/analytics/costs/summary?${VALID_DATE_RANGE}&groupBy=tags&tagKeys=${encodeURIComponent(tagKeys)}`
+    );
+
+    expect(res.status).toBe(200);
+    const args = mockDb.getCostSummary.mock.calls[0][0];
+    expect(args.tagKeys).toEqual(['orgId', 'teamName']);
+  });
+
+  test('ignores tagKeys when value is not an array', async () => {
+    const tagKeys = JSON.stringify({ key: 'value' });
+    const res = await app.request(
+      `/analytics/costs/summary?${VALID_DATE_RANGE}&groupBy=tags&tagKeys=${encodeURIComponent(tagKeys)}`
+    );
+
+    expect(res.status).toBe(200);
+    const args = mockDb.getCostSummary.mock.calls[0][0];
+    expect(args.tagKeys).toBeUndefined();
+  });
+
+  test('passes all filter params alongside tagKeys', async () => {
+    const tagKeys = JSON.stringify(['orgId']);
+    const configId = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
+    const tagsFilter = encodeURIComponent(JSON.stringify({ env: ['prod'] }));
+    const url = `/analytics/costs/summary?${VALID_DATE_RANGE}&groupBy=tags&tagKeys=${encodeURIComponent(tagKeys)}&configId=${configId}&tags=${tagsFilter}`;
+    const res = await app.request(url);
+
+    expect(res.status).toBe(200);
+    expect(mockDb.getCostSummary).toHaveBeenCalledOnce();
+    const args = mockDb.getCostSummary.mock.calls[0][0];
+    expect(args.tagKeys).toEqual(['orgId']);
+    expect(args.configId).toBe(configId);
+    expect(args.groupBy).toBe('tags');
+  });
+});
+
+describe('GET /analytics/costs/summary - general behavior', () => {
+  let mockDb: ReturnType<typeof createMockDb>;
+  let app: ReturnType<typeof createTestApp>;
+
+  beforeEach(() => {
+    mockDb = createMockDb();
+    app = createTestApp(mockDb);
+  });
+
+  test('returns 200 with empty array when no data', async () => {
+    const res = await app.request(
+      `/analytics/costs/summary?${VALID_DATE_RANGE}`
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data).toEqual([]);
+  });
+
+  test('returns data from getCostSummary', async () => {
+    const mockData = [
+      { groupKey: 'gpt-4', totalCost: 5000000, requestCount: 10 },
+      { groupKey: 'claude-3', totalCost: 3000000, requestCount: 5 },
+    ];
+    mockDb.getCostSummary.mockResolvedValue(mockData);
+
+    const res = await app.request(
+      `/analytics/costs/summary?${VALID_DATE_RANGE}&groupBy=model`
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data).toEqual(mockData);
+  });
+
+  test('returns 500 when getCostSummary throws', async () => {
+    mockDb.getCostSummary.mockRejectedValue(new Error('DB error'));
+
+    const res = await app.request(
+      `/analytics/costs/summary?${VALID_DATE_RANGE}&groupBy=model`
+    );
+
+    expect(res.status).toBe(500);
+  });
+
+  test('returns 400 for missing date range', async () => {
+    const res = await app.request(`/analytics/costs/summary`);
+    expect(res.status).toBe(400);
+  });
+});

--- a/packages/app/src/server/handlers/analytics/index.ts
+++ b/packages/app/src/server/handlers/analytics/index.ts
@@ -75,6 +75,7 @@ interface DbWithAnalytics {
     environmentId?: string;
     tags?: Record<string, string[]>;
     groupBy?: CostSummaryGroupBy;
+    tagKeys?: string[];
   }) => Promise<unknown[]>;
   getRequestStats: (params: {
     startDate: Date;
@@ -422,6 +423,7 @@ const app = new Hono()
       'query',
       dateRangeWithFiltersSchema.extend({
         groupBy: z.enum(COST_SUMMARY_GROUP_BY).optional(),
+        tagKeys: z.string().optional(),
       })
     ),
     async (c) => {
@@ -434,9 +436,19 @@ const app = new Hono()
         variantId,
         environmentId,
         tags,
+        tagKeys,
       } = c.req.valid('query');
 
       try {
+        let parsedTagKeys: string[] | undefined;
+        if (tagKeys) {
+          try {
+            const arr = JSON.parse(tagKeys);
+            if (Array.isArray(arr)) parsedTagKeys = arr.filter(Boolean);
+          } catch {
+            // ignore invalid JSON
+          }
+        }
         const data = await db.getCostSummary({
           startDate,
           endDate,
@@ -445,6 +457,7 @@ const app = new Hono()
           variantId,
           environmentId,
           tags: parseTags(tags),
+          tagKeys: parsedTagKeys,
         });
         return c.json(successResponse(data, 200));
       } catch (error) {

--- a/packages/core/src/datalayer/llmRequests.ts
+++ b/packages/core/src/datalayer/llmRequests.ts
@@ -115,6 +115,7 @@ const costSummarySchema = z.object({
   environmentId: z.string().uuid().optional(),
   tags: z.record(z.string(), z.array(z.string())).optional(), // { key: [value1, value2] }
   groupBy: z.enum(COST_SUMMARY_GROUP_BY).optional(),
+  tagKeys: z.array(z.string()).optional(),
 });
 
 /**
@@ -582,6 +583,7 @@ export const createLLMRequestsDataLayer = (db: Kysely<Database>) => {
         variantId,
         environmentId,
         tags,
+        tagKeys,
       } = result.data;
 
       // Base query with date filter
@@ -728,6 +730,14 @@ export const createLLMRequestsDataLayer = (db: Kysely<Database>) => {
                 );
               }
             }
+          }
+          // Filter to only selected tag keys when provided
+          if (tagKeys && tagKeys.length > 0) {
+            const tagKeyList = sql.join(
+              tagKeys.map((k) => sql`${k}`),
+              sql`, `
+            );
+            conditions.push(sql`t.key IN (${tagKeyList})`);
           }
           const whereClause = sql.join(conditions, sql` AND `);
           const result = await sql<{


### PR DESCRIPTION
When "Tags" is selected as cost distribution grouping, jsonb_each_text laterally expands every tag on every request, causing double-counted costs. This adds a tagKeys filter so users can select specific tag keys to break down by, with toggle chips UI and correct cost attribution.

- Add tagKeys parameter to costSummarySchema and SQL filter in core
- Pass tagKeys through API handler with JSON encoding
- Add tagKeys to useCostSummary hook params
- Add tag key selector chips UI to costs page
- Add handler tests for tagKeys parsing and edge cases