### PR TITLE
Allow empty config in validateLLMOpsConfig

### DIFF
--- a/packages/core/src/schemas/config.ts
+++ b/packages/core/src/schemas/config.ts
@@ -69,15 +69,7 @@ export const llmopsConfigSchema = llmopsConfigBaseSchema
       config.providers as InlineProvidersConfig | undefined
     ),
   }))
-  // Validate: either database or providers (including auto-detected) must exist
-  .refine(
-    (config) =>
-      config.database !== undefined ||
-      (config.providers && config.providers.length > 0),
-    'Either database or providers must be configured. ' +
-      'Set a database connection, configure providers explicitly, ' +
-      'or set API key environment variables (e.g., OPENAI_API_KEY).'
-  );
+;
 
 /**
  * Validated LLMOps configuration


### PR DESCRIPTION
Removes the validation that required either database or providers to be configured, allowing `llmops()` to be called with no arguments and no environment variables. 

Providers can be added later or will fail at request routing time with clear error messages, which is better UX than failing at initialization. This gives the SDK more flexibility for different usage patterns.