### PR TITLE
feat(sdk): wire eval + telemetry contracts onto core spine

### DIFF
--- a/packages/sdk/src/eval/dataset.ts
+++ b/packages/sdk/src/eval/dataset.ts
@@ -1,15 +1,9 @@
-import type { Datapoint } from './types';
+import type { Datapoint, EvaluationDataset } from '@llmops/core';
 
-/**
- * Interface for custom dataset sources.
- * Built-in: inline arrays are wrapped in InlineDataset automatically.
- * Future: CSVDataset, JSONLDataset, S3Dataset.
- */
-export interface EvaluationDataset<D = Record<string, unknown>, T = Record<string, unknown>> {
-  size(): number | Promise<number>;
-  get(index: number): Datapoint<D, T> | Promise<Datapoint<D, T>>;
-  slice(start: number, end: number): Datapoint<D, T>[] | Promise<Datapoint<D, T>[]>;
-}
+// `EvaluationDataset` and `Datapoint` are defined in @llmops/core (the shared
+// spine), so a telemetry-backed dataset and an inline array satisfy the same
+// contract. Re-exported here so existing `@llmops/sdk/eval` imports resolve.
+export type { EvaluationDataset };
 
 /**
  * Wraps a plain array as an EvaluationDataset.

--- a/packages/sdk/src/eval/evaluate.ts
+++ b/packages/sdk/src/eval/evaluate.ts
@@ -1,9 +1,8 @@
 import { randomUUID } from 'node:crypto';
 import { writeFileSync, mkdirSync } from 'node:fs';
-import { join, dirname } from 'node:path';
+import { join } from 'node:path';
 import { InlineDataset, type EvaluationDataset } from './dataset';
 import type {
-  Datapoint,
   DatapointResult,
   EvaluateOptions,
   EvaluateResult,

--- a/packages/sdk/src/eval/types.ts
+++ b/packages/sdk/src/eval/types.ts
@@ -1,11 +1,8 @@
-/**
- * A single datapoint in a dataset.
- */
-export interface Datapoint<D = Record<string, unknown>, T = Record<string, unknown>> {
-  data: D;
-  target?: T;
-  metadata?: Record<string, unknown>;
-}
+import type { Datapoint } from '@llmops/core';
+
+// `Datapoint` now lives in @llmops/core (the shared spine). Re-exported here so
+// existing `@llmops/sdk/eval` type imports keep resolving from one source.
+export type { Datapoint };
 
 /**
  * An evaluator scores executor output.

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -31,3 +31,18 @@ export type {
   SpanEventInsert,
 } from './telemetry/types';
 export { COST_SUMMARY_GROUP_BY, type CostSummaryGroupBy } from './telemetry/constants';
+
+// Telemetry spine contracts (from @llmops/core). Producers (the gateway, evals)
+// emit through TelemetrySink; the dashboard and dataset-bridge read through
+// TelemetryReader. NB: core also defines TelemetryStore = Sink & Reader; the
+// concrete store interface above will converge onto it when the stores are
+// reworked (see DESIGN.md, step 3).
+export type {
+  TelemetrySink,
+  TelemetryEvent,
+  TelemetryReader,
+  LLMRequestRecord,
+  SpanRecord,
+  TraceRecord,
+  TokenUsage,
+} from '@llmops/core';

--- a/packages/sdk/src/store/d1/d1-store.ts
+++ b/packages/sdk/src/store/d1/d1-store.ts
@@ -105,7 +105,7 @@ function createD1LLMRequestsStore(db: D1Database) {
 
     insertRequest: async (req: LLMRequestInsert) => {
       const now = new Date().toISOString();
-      return db.prepare(`
+      const result = await db.prepare(`
         INSERT INTO "llm_requests" (
           "id","requestId","configId","variantId","environmentId",
           "providerConfigId","provider","model","promptTokens",

--- a/packages/sdk/src/telemetry/pg-store.ts
+++ b/packages/sdk/src/telemetry/pg-store.ts
@@ -7,6 +7,13 @@ import {
   insertSpanEventSchema,
   upsertTraceSchema,
 } from './types';
+import type {
+  LLMRequestInsert,
+  TraceUpsert,
+  SpanInsert,
+  SpanEventInsert,
+  CostSummaryGroupBy,
+} from './types';
 
 export type {
   LLMRequestInsert,


### PR DESCRIPTION
## What

Step 2 of the spine rollout (`DESIGN.md`): wire `@llmops/sdk` onto the `@llmops/core` contracts from #72, and fix the pre-existing typecheck breakage.

## Changes

- **Eval contracts → single source of truth.** `Datapoint` and `EvaluationDataset` now re-export from `@llmops/core`; `InlineDataset` (the impl) stays in the SDK. `@llmops/sdk/eval` consumers are unchanged.
- **Expose the telemetry spine.** The SDK root re-exports `TelemetrySink`, `TelemetryEvent`, `TelemetryReader`, `LLMRequestRecord` / `SpanRecord` / `TraceRecord`, `TokenUsage` from core — so producers can implement a custom sink.
- **Green the build** (pre-existing failures, confirmed identical on `v1.0.0`):
  - `pg-store.ts` re-exported the insert types but never imported them → `Cannot find name 'LLMRequestInsert'` (+4). Added the local `import type`.
  - `d1-store.ts` `insertRequest` early-returned the raw row, leaving a second `return result …` unreachable and `result` undefined. Now assigns + parses.
  - `evaluate.ts` dropped unused `dirname` / `Datapoint` imports.

## Scope (deliberately narrow)

The insert schemas are DB-row-shaped (flat tokens, integer-cents cost, `configId`/`statusCode`/`endpoint`) — quite different from the clean domain `*Record` types. Forcing them to derive from the records would ripple into all three stores + the app, so that **structural store↔Sink/Reader reconciliation is deferred to step 3** (headless telemetry). This PR keeps store/app signatures untouched.

## Verify

- `@llmops/sdk` typecheck — ✅ green (was 10 errors)
- `@llmops/sdk` build — ✅ green
- No change to the concrete `TelemetryStore` interface or any store method signature.

Base `v1.0.0`.
