### PR TITLE
feat(sdk): StoreSink adapter + ops.observe() for headless telemetry

### DIFF
--- a/packages/sdk/src/client/index.ts
+++ b/packages/sdk/src/client/index.ts
@@ -15,6 +15,10 @@ import {
   createLLMOpsLangChainClient,
   type LangChainTracingClient,
 } from '../telemetry/langchain-client';
+import { createStoreSink } from '../telemetry/store-sink';
+import { noopSink, observe, type Observation } from '../telemetry/observe';
+import type { TelemetrySink } from '@llmops/core';
+import type { TelemetryStore } from '../telemetry/interface';
 
 type ProviderConfig = {
   baseURL: string;
@@ -32,18 +36,39 @@ export type ProviderOptions = {
   traceContext?: () => TraceContext | null;
 };
 
+function resolveTelemetryStore(telemetry: unknown) {
+  if (!telemetry) return null;
+  if (Array.isArray(telemetry)) return telemetry[0] ?? null;
+  return telemetry;
+}
+
 export type LLMOpsClient = {
   handler: (request: Request) => Promise<Response>;
   config: ValidatedLLMOpsConfig;
   provider: (options?: ProviderOptions) => ProviderConfig;
   agentsExporter: () => AgentsTracingExporter;
   langchainTracer: () => LangChainTracingClient;
+  telemetry: TelemetrySink;
+  observe: (params: {
+    provider: string;
+    model: string;
+    traceId?: string;
+    tags?: Record<string, string>;
+  }) => Observation;
 };
 
 export const createLLMOps = (config?: LLMOpsConfig): LLMOpsClient => {
   const { app, config: validatedConfig } = createApp(config);
   const handler = async (req: Request) => app.fetch(req, undefined, undefined);
   const basePath = validatedConfig.basePath;
+
+  // Build telemetry sink from configured store (headless — works without the HTTP app)
+  const store = resolveTelemetryStore(validatedConfig.telemetry);
+  const sink = store
+    ? createStoreSink(store as TelemetryStore, {
+        flushIntervalMs: 2000,
+      })
+    : noopSink;
 
   const createInternalFetch = (
     getTraceContext?: () => TraceContext | null,
@@ -108,5 +133,7 @@ export const createLLMOps = (config?: LLMOpsConfig): LLMOpsClient => {
         apiKey: 'llmops',
         fetch: createInternalFetch(),
       }),
+    telemetry: sink,
+    observe: (params) => observe(sink, params),
   };
 };

--- a/packages/sdk/src/client/index.ts
+++ b/packages/sdk/src/client/index.ts
@@ -67,6 +67,7 @@ export const createLLMOps = (config?: LLMOpsConfig): LLMOpsClient => {
   const sink = store
     ? createStoreSink(store as TelemetryStore, {
         flushIntervalMs: 2000,
+        waitUntil: validatedConfig.waitUntil,
       })
     : noopSink;
 

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -46,3 +46,7 @@ export type {
   TraceRecord,
   TokenUsage,
 } from '@llmops/core';
+
+// Sink + observe — headless telemetry primitives
+export { createStoreSink, type StoreSinkConfig, type StoreSink } from './telemetry/store-sink';
+export { noopSink, observe, type Observation } from './telemetry/observe';

--- a/packages/sdk/src/telemetry/observe.ts
+++ b/packages/sdk/src/telemetry/observe.ts
@@ -1,0 +1,68 @@
+import type { TelemetrySink } from '@llmops/core';
+
+export const noopSink: TelemetrySink = {
+  emit: () => {},
+  flush: async () => {},
+};
+
+export interface Observation {
+  traceId: string;
+  spanId: string;
+  complete(result: {
+    status: 'success' | 'error';
+    usage?: {
+      inputTokens?: number;
+      outputTokens?: number;
+      cacheReadTokens?: number;
+      cacheWriteTokens?: number;
+    };
+    cost?: number;
+    latencyMs?: number;
+    input?: unknown;
+    output?: unknown;
+    error?: string;
+  }): void;
+}
+
+export function observe(
+  sink: TelemetrySink,
+  params: {
+    provider: string;
+    model: string;
+    traceId?: string;
+    tags?: Record<string, string>;
+  },
+): Observation {
+  const requestId = crypto.randomUUID();
+  const spanId = crypto.randomUUID().replace(/-/g, '').slice(0, 16);
+  const traceId = params.traceId ?? crypto.randomUUID().replace(/-/g, '');
+  const startedAt = new Date().toISOString();
+
+  return {
+    traceId,
+    spanId,
+    complete(result) {
+      sink.emit([
+        {
+          type: 'llm_request',
+          request: {
+            requestId,
+            traceId,
+            spanId,
+            provider: params.provider,
+            model: params.model,
+            input: result.input,
+            output: result.output,
+            usage: result.usage,
+            cost: result.cost,
+            latencyMs: result.latencyMs,
+            status: result.status,
+            error: result.error,
+            tags: params.tags,
+            startedAt,
+          },
+        },
+      ]);
+    },
+  };
+}

--- a/packages/sdk/src/telemetry/store-sink.ts
+++ b/packages/sdk/src/telemetry/store-sink.ts
@@ -1,0 +1,171 @@
+import type {
+  TelemetrySink,
+  TelemetryEvent,
+  LLMRequestRecord,
+  SpanRecord,
+  TraceRecord,
+} from '@llmops/core';
+import { dollarsToMicroDollars } from '@llmops/core';
+import type { LLMRequestInsert, SpanInsert, TraceUpsert } from './types';
+import type { TelemetryStore } from './interface';
+
+export interface StoreSinkConfig {
+  flushIntervalMs?: number;
+  maxBatchSize?: number;
+}
+
+export type StoreSink = TelemetrySink;
+
+export function createStoreSink(
+  store: TelemetryStore,
+  config: StoreSinkConfig = {},
+): StoreSink {
+  const { flushIntervalMs = 2000, maxBatchSize = 100 } = config;
+
+  let queue: TelemetryEvent[] = [];
+  let started = false;
+
+  function ensureStarted(): void {
+    if (started) return;
+    started = true;
+    setInterval(() => {
+      flush().catch(() => {});
+    }, flushIntervalMs);
+  }
+
+  async function flush(): Promise<void> {
+    if (queue.length === 0) return;
+    const batch = queue;
+    queue = [];
+
+    const requests: LLMRequestInsert[] = [];
+    const spans: SpanInsert[] = [];
+    const traces: TraceUpsert[] = [];
+
+    for (const event of batch) {
+      if (event.type === 'llm_request') {
+        requests.push(convertRequest(event.request));
+      } else {
+        spans.push(convertSpan(event.span));
+        if (event.trace) {
+          traces.push(convertTrace(event.trace));
+        }
+      }
+    }
+
+    const tasks: Promise<unknown>[] = [];
+    if (requests.length > 0) tasks.push(store.batchInsertRequests(requests));
+    if (spans.length > 0) tasks.push(store.batchInsertSpans(spans));
+    for (const trace of traces) tasks.push(store.upsertTrace(trace));
+
+    await Promise.allSettled(tasks);
+  }
+
+  function emit(events: TelemetryEvent[]): void {
+    queue.push(...events);
+    ensureStarted();
+    if (queue.length >= maxBatchSize) {
+      flush().catch(() => {});
+    }
+  }
+
+  return { emit, flush };
+}
+
+function convertRequest(r: LLMRequestRecord): LLMRequestInsert {
+  const promptTokens = r.usage?.inputTokens ?? 0;
+  const completionTokens = r.usage?.outputTokens ?? 0;
+  return {
+    requestId: r.requestId,
+    provider: r.provider,
+    model: r.model,
+    promptTokens,
+    completionTokens,
+    totalTokens: promptTokens + completionTokens,
+    cachedTokens: r.usage?.cacheReadTokens ?? 0,
+    cacheCreationTokens: r.usage?.cacheWriteTokens ?? 0,
+    cost: r.cost != null ? dollarsToMicroDollars(r.cost) : 0,
+    cacheSavings: 0,
+    inputCost: 0,
+    outputCost: 0,
+    endpoint: '/chat/completions',
+    statusCode: r.status === 'error' ? 500 : 200,
+    latencyMs: r.latencyMs ?? 0,
+    isStreaming: false,
+    tags: r.tags ?? {},
+    traceId: r.traceId ?? null,
+    spanId: r.spanId ?? null,
+  };
+}
+
+const KIND_MAP: Record<string, number> = {
+  unspecified: 0,
+  internal: 1,
+  llm: 1,
+  chain: 1,
+  agent: 1,
+  server: 2,
+  tool: 3,
+  client: 3,
+  retrieval: 3,
+  producer: 4,
+  consumer: 5,
+};
+
+function convertSpan(span: SpanRecord): SpanInsert {
+  const startTime = new Date(span.startedAt);
+  const endTime = span.endedAt ? new Date(span.endedAt) : null;
+  const durationMs =
+    endTime != null ? endTime.getTime() - startTime.getTime() : null;
+  const promptTokens = span.usage?.inputTokens ?? 0;
+  const completionTokens = span.usage?.outputTokens ?? 0;
+
+  return {
+    traceId: span.traceId,
+    spanId: span.spanId,
+    parentSpanId: span.parentSpanId ?? null,
+    name: span.name,
+    kind: span.kind ? (KIND_MAP[span.kind] ?? 1) : 1,
+    status: span.status === 'error' ? 2 : 1,
+    statusMessage: span.error ?? null,
+    startTime,
+    endTime,
+    durationMs,
+    provider:
+      (span.attributes?.['gen_ai.provider.name'] as string) ?? null,
+    model: (span.attributes?.['gen_ai.request.model'] as string) ?? null,
+    promptTokens,
+    completionTokens,
+    totalTokens: promptTokens + completionTokens,
+    cost: span.cost != null ? dollarsToMicroDollars(span.cost) : 0,
+    source: 'gateway',
+    input: span.input ?? null,
+    output: span.output ?? null,
+    attributes: span.attributes ?? {},
+  };
+}
+
+function convertTrace(trace: TraceRecord): TraceUpsert {
+  const startTime = new Date(trace.startedAt);
+  const endTime = trace.endedAt ? new Date(trace.endedAt) : null;
+  const durationMs =
+    endTime != null ? endTime.getTime() - startTime.getTime() : null;
+
+  return {
+    traceId: trace.traceId,
+    name: trace.name,
+    sessionId: trace.sessionId ?? null,
+    userId: trace.userId ?? null,
+    status: trace.status ?? 'unset',
+    startTime,
+    endTime,
+    durationMs,
+    spanCount: 1,
+    totalInputTokens: 0,
+    totalOutputTokens: 0,
+    totalTokens: 0,
+    totalCost: 0,
+    tags: {},
+    metadata: trace.metadata ?? {},
+  };
+}

--- a/packages/sdk/src/telemetry/store-sink.ts
+++ b/packages/sdk/src/telemetry/store-sink.ts
@@ -5,13 +5,20 @@ import type {
   SpanRecord,
   TraceRecord,
 } from '@llmops/core';
-import { dollarsToMicroDollars } from '@llmops/core';
+import { dollarsToMicroDollars, logger } from '@llmops/core';
 import type { LLMRequestInsert, SpanInsert, TraceUpsert } from './types';
 import type { TelemetryStore } from './interface';
 
 export interface StoreSinkConfig {
   flushIntervalMs?: number;
   maxBatchSize?: number;
+  /**
+   * Edge runtimes (Cloudflare Workers, Vercel Edge): pass
+   * `ctx.waitUntil.bind(ctx)`. When provided, the sink flushes in the
+   * background tied to the request lifecycle instead of starting a
+   * `setInterval` — which does not run between requests on Workers.
+   */
+  waitUntil?: (promise: Promise<unknown>) => void;
 }
 
 export type StoreSink = TelemetrySink;
@@ -20,17 +27,19 @@ export function createStoreSink(
   store: TelemetryStore,
   config: StoreSinkConfig = {},
 ): StoreSink {
-  const { flushIntervalMs = 2000, maxBatchSize = 100 } = config;
+  const { flushIntervalMs = 2000, maxBatchSize = 100, waitUntil } = config;
 
   let queue: TelemetryEvent[] = [];
-  let started = false;
+  let timer: ReturnType<typeof setInterval> | null = null;
 
-  function ensureStarted(): void {
-    if (started) return;
-    started = true;
-    setInterval(() => {
-      flush().catch(() => {});
+  function ensureTimer(): void {
+    // Edge path uses waitUntil (in emit); no background timer needed there.
+    if (waitUntil || timer) return;
+    timer = setInterval(() => {
+      flush().catch(logFlushError);
     }, flushIntervalMs);
+    // Never keep a short-lived process (e.g. the eval CLI) alive just to flush.
+    (timer as { unref?: () => void }).unref?.();
   }
 
   async function flush(): Promise<void> {
@@ -58,15 +67,34 @@ export function createStoreSink(
     if (spans.length > 0) tasks.push(store.batchInsertSpans(spans));
     for (const trace of traces) tasks.push(store.upsertTrace(trace));
 
-    await Promise.allSettled(tasks);
+    // Telemetry is best-effort: surface failures, never throw into the caller.
+    const results = await Promise.allSettled(tasks);
+    const failed = results.filter((r) => r.status === 'rejected').length;
+    if (failed > 0) {
+      logger.warn(
+        `[StoreSink] ${failed}/${tasks.length} telemetry write(s) failed; ${batch.length} event(s) dropped`,
+      );
+    }
   }
 
   function emit(events: TelemetryEvent[]): void {
+    if (events.length === 0) return;
     queue.push(...events);
-    ensureStarted();
-    if (queue.length >= maxBatchSize) {
-      flush().catch(() => {});
+    if (waitUntil) {
+      // Edge: persist in the background, bound to the request's lifetime.
+      waitUntil(flush().catch(logFlushError));
+      return;
     }
+    ensureTimer();
+    if (queue.length >= maxBatchSize) {
+      flush().catch(logFlushError);
+    }
+  }
+
+  function logFlushError(err: unknown): void {
+    logger.warn(
+      `[StoreSink] flush failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
   }
 
   return { emit, flush };


### PR DESCRIPTION
## Summary

Step 3 of the v1 rollout — headless telemetry.

### What's new

**`StoreSink`** (`packages/sdk/src/telemetry/store-sink.ts`)
- Adapts a `TelemetryStore` (concrete store with `batchInsertRequests`, `batchInsertSpans`, `upsertTrace`) into a `TelemetrySink` (core's typed write interface)
- Converts `TelemetryEvent[]` → store's DB-row insert schemas:
  - `LLMRequestRecord` → `LLMRequestInsert` (USD float → integer micro-dollars via `dollarsToMicroDollars`, string status → numeric statusCode, etc.)
  - `SpanRecord` → `SpanInsert` (ISO timestamp → Date, string kind → OTel numeric kind, USD → micro-dollars)
  - `TraceRecord` → `TraceUpsert`
- Internal batching with interval flushing (reuses the pattern from `batchWriter.ts`/`traceBatchWriter.ts` but unified and singleton-free)

**`ops.observe()`** (`packages/sdk/src/telemetry/observe.ts`)
- Manual LLM call tracking — for when you call providers directly, not through the gateway
- Fire-and-forget by contract: `ops.observe({ provider, model })` → `.complete({ status, usage, cost })` → emits a `TelemetryEvent` to the sink
- Uses Web Crypto `crypto.randomUUID()` (edge-compatible, no `node:crypto` import)

**`noopSink`** — default when no telemetry store is configured

### Client API

```ts
const ops = llmops({ telemetry: pgStore(process.env.DATABASE_URL) })

// Manual observation (headless — no HTTP gateway needed)
const obs = ops.observe({ provider: 'openai', model: 'gpt-4o' })
// ... your LLM call ...
obs.complete({ status: 'success', usage: { inputTokens: 100, outputTokens: 50 }, cost: 0.003 })

// Direct sink access (for custom producers)
ops.telemetry.emit([{ type: 'span', span: { ... } }])
await ops.telemetry.flush()
```

### What's NOT here yet (deferred to step 4)

- The cost tracking middleware in `@llmops/app` still uses its own batch writers directly — refactored when the gateway is rewritten
- OTLP handler still writes directly to traceBatchWriter — refactor deferred
- `ops.trace()` for manual tracing — can be layered on top of `ops.telemetry.emit()` later

### Files

| File | Change |
|------|--------|
| `packages/sdk/src/telemetry/store-sink.ts` | **NEW** — StoreSink adapter |
| `packages/sdk/src/telemetry/observe.ts` | **NEW** — noopSink + observe() helper |
| `packages/sdk/src/client/index.ts` | Wire `ops.telemetry` + `ops.observe()` into LLMOpsClient |
| `packages/sdk/src/index.ts` | Export `createStoreSink`, `noopSink`, `observe` |

Net: +270 lines across 2 new + 2 modified files.