### PR TITLE
feat(sdk): add createOpenAIProvider() gateway config factory

### DIFF
--- a/packages/sdk/src/client/index.ts
+++ b/packages/sdk/src/client/index.ts
@@ -16,7 +16,7 @@ import {
   type LangChainTracingClient,
 } from '../telemetry/langchain-client';
 
-type ProviderConfig = {
+export type ProviderConfig = {
   baseURL: string;
   apiKey: string;
   fetch: typeof globalThis.fetch;

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -5,7 +5,9 @@ export {
   type LLMOpsClient,
   type TraceContext,
   type ProviderOptions,
+  type ProviderConfig,
 } from './client';
+export { createOpenAIProvider } from './providers/openai';
 export {
   createLLMOpsSpanExporter,
   type LLMOpsExporterConfig,

--- a/packages/sdk/src/providers/openai.ts
+++ b/packages/sdk/src/providers/openai.ts
@@ -1,0 +1,25 @@
+import type { LLMOpsClient, ProviderConfig, ProviderOptions } from '../client';
+
+/**
+ * Gateway connection config for the OpenAI SDK.
+ *
+ * ```ts
+ * const provider = createOpenAIProvider(ops)
+ * const openai = new OpenAI(provider)
+ * await openai.chat.completions.create({ model: '@openai/gpt-4o', messages })
+ * ```
+ *
+ * Returns `{ baseURL, apiKey, fetch }` wired to the in-process gateway — pass it
+ * straight to `new OpenAI(...)`. For OpenAI (the gateway's native protocol) this
+ * is a named pass-through of `ops.provider()`; the per-SDK factory shape is what
+ * keeps non-OpenAI SDKs (e.g. Anthropic, with a different base path) clean.
+ *
+ * Need extra OpenAI client options? Merge them at construction:
+ * `new OpenAI({ ...createOpenAIProvider(ops), timeout: 30_000 })`.
+ */
+export function createOpenAIProvider(
+  ops: LLMOpsClient,
+  options?: ProviderOptions,
+): ProviderConfig {
+  return ops.provider(options);
+}


### PR DESCRIPTION
## What

`createOpenAIProvider(ops)` — a named factory returning the gateway connection config for the OpenAI SDK:

```ts
const provider = createOpenAIProvider(ops)
const openai = new OpenAI(provider)
await openai.chat.completions.create({ model: '@openai/gpt-4o', messages })
```

## Why
`new OpenAI(ops.provider())` works but is low-level and implicitly OpenAI-shaped. This is the explicit, discoverable entry point — and the first of a per-SDK family (Anthropic next, which needs a different base path).

## Shape
- Returns `ProviderConfig` (`{ baseURL, apiKey, fetch }`) — pass straight to `new OpenAI(...)`. For OpenAI (the gateway's native protocol) it's a named pass-through of `ops.provider()`.
- Returns **config, not a constructed client** → never imports `openai` → no peer dep, no subpath, stays in the edge-safe main bundle.
- Extra OpenAI options merge at construction: `new OpenAI({ ...createOpenAIProvider(ops), timeout: 30_000 })`.

## Changes
- new `packages/sdk/src/providers/openai.ts`
- export `createOpenAIProvider` + the now-public `ProviderConfig` type from the SDK root

## Verify
- `pnpm --filter @llmops/sdk typecheck` + `build` green
- `createOpenAIProvider` / `ProviderConfig` present in the public `dist/index.d.mts`
- main bundle has **zero** runtime import of `openai` (edge-safety)

Base `v1.0.0`. `createAnthropicProvider` (different base path, peer-dep `@anthropic-ai/sdk`) is a deferred follow-up.
