### PR TITLE
feat(gateway): minimal OpenAI-compatible proxy (router + resolve + execute)

### DIFF
--- a/packages/gateway/src/execute.ts
+++ b/packages/gateway/src/execute.ts
@@ -1,0 +1,47 @@
+import type { ProviderAdapter } from './providers/types';
+import { err, ok, type Result } from './result';
+import type { ProviderConfig } from './types/provider';
+import type { RequestType } from './types/requests';
+import { type GatewayError, serverError } from './utils/responses';
+
+/**
+ * Build the upstream request from the adapter + config, send it, and return the
+ * response. Pass-through by default: the (model-rewritten) body is forwarded and
+ * the upstream response — stream included — is returned as-is.
+ */
+export async function executeRequest(
+  adapter: ProviderAdapter,
+  config: ProviderConfig,
+  requestType: RequestType,
+  request: Request,
+  body: string,
+  fetchImpl: typeof globalThis.fetch,
+): Promise<Result<Response, GatewayError>> {
+  const endpoint = adapter.endpoints[requestType];
+  if (!endpoint) {
+    return err({
+      status: 404,
+      type: 'not_found_error',
+      message: `Provider "${adapter.name}" does not support ${requestType}.`,
+    });
+  }
+
+  const url = endpoint.getURL(config, requestType);
+  const headers: Record<string, string> = {
+    'content-type': 'application/json',
+    ...endpoint.getHeaders(config, request),
+  };
+
+  try {
+    const upstream = await fetchImpl(url, {
+      method: request.method,
+      headers,
+      body,
+    });
+    return ok(upstream);
+  } catch (error) {
+    return serverError(
+      error instanceof Error ? error.message : 'Upstream request failed.',
+    );
+  }
+}

--- a/packages/gateway/src/gateway.test.ts
+++ b/packages/gateway/src/gateway.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createGateway } from './gateway';
+
+function jsonResponse(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+function chatRequest(model: string): Request {
+  return new Request('http://gateway/api/genai/v1/chat/completions', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ model, messages: [{ role: 'user', content: 'hi' }] }),
+  });
+}
+
+describe('createGateway', () => {
+  it('routes @openai/gpt-4o upstream with Bearer auth and a stripped model', async () => {
+    const fetchMock = vi.fn(async () => jsonResponse({ id: 'ok' }));
+    const gw = createGateway({
+      providers: [{ provider: 'openai', slug: 'openai', apiKey: 'sk-test' }],
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+
+    const res = await gw(chatRequest('@openai/gpt-4o'));
+    expect(res.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://api.openai.com/v1/chat/completions');
+    expect((init.headers as Record<string, string>).Authorization).toBe(
+      'Bearer sk-test',
+    );
+    expect(JSON.parse(init.body as string).model).toBe('gpt-4o');
+  });
+
+  it('honors a custom slug + baseURL (OpenAI-compatible by default)', async () => {
+    const fetchMock = vi.fn(async () => jsonResponse({ id: 'ok' }));
+    const gw = createGateway({
+      providers: [
+        {
+          provider: 'groq',
+          slug: 'fast',
+          apiKey: 'gsk',
+          baseURL: 'https://example.com/v1',
+        },
+      ],
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+
+    await gw(chatRequest('@fast/llama-3.1-70b'));
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://example.com/v1/chat/completions');
+    expect(JSON.parse(init.body as string).model).toBe('llama-3.1-70b');
+  });
+
+  it('returns the upstream response body unchanged (pass-through)', async () => {
+    const fetchMock = vi.fn(async () =>
+      jsonResponse({ id: 'chatcmpl-1', ok: true }),
+    );
+    const gw = createGateway({
+      providers: [{ provider: 'openai', slug: 'openai', apiKey: 'x' }],
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+    const res = await gw(chatRequest('@openai/gpt-4o'));
+    expect(await res.json()).toEqual({ id: 'chatcmpl-1', ok: true });
+  });
+
+  it('400s when the model lacks the @slug/ prefix', async () => {
+    const gw = createGateway({
+      providers: [{ provider: 'openai', slug: 'openai', apiKey: 'x' }],
+    });
+    expect((await gw(chatRequest('gpt-4o'))).status).toBe(400);
+  });
+
+  it('400s for an unconfigured slug', async () => {
+    const gw = createGateway({
+      providers: [{ provider: 'openai', slug: 'openai', apiKey: 'x' }],
+    });
+    expect((await gw(chatRequest('@unknown/model'))).status).toBe(400);
+  });
+
+  it('404s for an unroutable path', async () => {
+    const gw = createGateway({});
+    const res = await gw(
+      new Request('http://gateway/nope', { method: 'POST', body: '{}' }),
+    );
+    expect(res.status).toBe(404);
+  });
+});

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -1,0 +1,69 @@
+import { executeRequest } from './execute';
+import { parseModel, resolveTarget } from './resolve';
+import { matchRoute } from './router';
+import type { GatewayConfig, ProviderInput } from './types/config';
+import { errorResponse } from './utils/responses';
+
+/** The in-process gateway handler — a plug you mount, not a proxy you route to. */
+export type GatewayHandler = (req: Request) => Promise<Response>;
+
+/**
+ * Create the gateway plug.
+ *
+ * Routes an OpenAI-shaped request (`@provider-slug/model` in the body) to the
+ * configured provider and streams the response straight back — pass-through by
+ * default. Non-OpenAI-compliant providers plug in via `config.adapters`.
+ */
+export function createGateway(config: GatewayConfig = {}): GatewayHandler {
+  const providers = new Map<string, ProviderInput>(
+    (config.providers ?? []).map((p) => [p.slug, p]),
+  );
+  const fetchImpl = config.fetch ?? globalThis.fetch;
+
+  return async (req) => {
+    const pathname = new URL(req.url).pathname;
+    const requestType = matchRoute(pathname);
+    if (!requestType) {
+      return errorResponse({
+        status: 404,
+        type: 'not_found_error',
+        message: `No route for ${pathname}.`,
+      });
+    }
+
+    let payload: Record<string, unknown>;
+    try {
+      payload = (await req.json()) as Record<string, unknown>;
+    } catch {
+      return errorResponse({
+        status: 400,
+        type: 'invalid_request_error',
+        message: 'Request body must be valid JSON.',
+      });
+    }
+
+    const parsed = parseModel(payload.model);
+    if (!parsed.ok) return errorResponse(parsed.error);
+
+    const resolved = resolveTarget(
+      parsed.value.slug,
+      parsed.value.model,
+      providers,
+      config.adapters,
+    );
+    if (!resolved.ok) return errorResponse(resolved.error);
+
+    // Strip the `@slug/` prefix so the upstream sees its own bare model id.
+    const body = JSON.stringify({ ...payload, model: parsed.value.model });
+
+    const result = await executeRequest(
+      resolved.value.adapter,
+      resolved.value.config,
+      requestType,
+      req,
+      body,
+      fetchImpl,
+    );
+    return result.ok ? result.value : errorResponse(result.error);
+  };
+}

--- a/packages/gateway/src/index.ts
+++ b/packages/gateway/src/index.ts
@@ -1,12 +1,23 @@
 // @llmops/gateway — a plug, not a proxy.
 //
-// Step 1 lands the zero-dependency foundation: a hand-rolled Result, the
-// ProviderConfig / RequestType types, the ProviderAdapter / EndpointConfig
-// contract, header utilities, and OpenAI-compatible error responses.
-//
-// The gateway implementation (routing, provider resolution, pass-through
-// execution, usage/cost + telemetry) lands in the following steps.
+// A pure `(req: Request) => Promise<Response>` handler you mount in-process.
+// OpenAI-compatible by default: it routes `@provider-slug/model` requests to the
+// configured provider and streams the response straight back (pass-through).
+// Providers that diverge from OpenAI plug in via custom adapters.
 
+export { createGateway, type GatewayHandler } from './gateway';
+export type { GatewayConfig, ProviderInput } from './types/config';
+
+// Routing + resolution (exported for testing / advanced composition).
+export { executeRequest } from './execute';
+export { parseModel, type ResolvedTarget, resolveTarget } from './resolve';
+export { matchRoute } from './router';
+
+// Providers.
+export { openaiCompatible } from './providers/openai-compatible';
+export { DEFAULT_BASE_URLS, getAdapter } from './providers/registry';
+
+// Foundation.
 export { err, isErr, isOk, ok, type Result } from './result';
 export { RequestType } from './types/requests';
 export type { ProviderConfig } from './types/provider';
@@ -28,24 +39,3 @@ export {
   serverError,
   successResponse,
 } from './utils/responses';
-
-import { errorResponse } from './utils/responses';
-
-/** The in-process gateway handler: a plug you mount, not a proxy you route to. */
-export type GatewayHandler = (req: Request) => Promise<Response>;
-
-/**
- * Create the gateway plug.
- *
- * NOT YET IMPLEMENTED — the foundation is in place; routing, provider
- * resolution, pass-through execution, and telemetry land in the next steps.
- * Returns a handler that responds 501 until then.
- */
-export function createGateway(): GatewayHandler {
-  return async () =>
-    errorResponse({
-      status: 501,
-      type: 'server_error',
-      message: 'Gateway not implemented yet (foundation only).',
-    });
-}

--- a/packages/gateway/src/providers/openai-compatible.ts
+++ b/packages/gateway/src/providers/openai-compatible.ts
@@ -1,0 +1,26 @@
+import { RequestType } from '../types/requests';
+import type { EndpointConfig, ProviderAdapter } from './types';
+import { bearerAuthHeader, defaultURL, extractForwardHeaders } from './utils';
+
+/**
+ * The default adapter: assume an OpenAI-compatible provider. Every endpoint is
+ * pure pass-through — `<baseURL><path>` with a Bearer auth header, body
+ * forwarded untouched. Providers that diverge from OpenAI register their own
+ * adapter instead of using this.
+ */
+export function openaiCompatible(name: string): ProviderAdapter {
+  const endpoint: EndpointConfig = {
+    getURL: (config, requestType) =>
+      defaultURL(config.baseURL ?? '', requestType),
+    getHeaders: (config, request) => ({
+      ...bearerAuthHeader(config.apiKey),
+      ...extractForwardHeaders(config, request),
+    }),
+  };
+  return {
+    name,
+    endpoints: Object.fromEntries(
+      Object.values(RequestType).map((rt) => [rt, endpoint]),
+    ) as Record<RequestType, EndpointConfig>,
+  };
+}

--- a/packages/gateway/src/providers/registry.ts
+++ b/packages/gateway/src/providers/registry.ts
@@ -1,0 +1,40 @@
+import { openaiCompatible } from './openai-compatible';
+import type { ProviderAdapter } from './types';
+
+/**
+ * Default base URLs for well-known OpenAI-compatible providers. Any provider can
+ * also be reached by passing an explicit `baseURL` — this map is convenience.
+ */
+export const DEFAULT_BASE_URLS: Record<string, string> = {
+  openai: 'https://api.openai.com/v1',
+  groq: 'https://api.groq.com/openai/v1',
+  mistral: 'https://api.mistral.ai/v1',
+  together: 'https://api.together.xyz/v1',
+  fireworks: 'https://api.fireworks.ai/inference/v1',
+  deepseek: 'https://api.deepseek.com',
+  openrouter: 'https://openrouter.ai/api/v1',
+  xai: 'https://api.x.ai/v1',
+  cerebras: 'https://api.cerebras.ai/v1',
+};
+
+/**
+ * Adapters for providers that are NOT OpenAI-compliant (Anthropic, Bedrock, …).
+ * Empty for now — filled in incrementally as those providers are added.
+ */
+const SPECIAL_ADAPTERS: Record<string, ProviderAdapter> = {};
+
+/**
+ * Resolve the adapter for a provider. Defaults to OpenAI-compatible pass-through
+ * for anything without a special adapter — the core of the design: OpenAI by
+ * default, deltas only where a provider actually diverges.
+ */
+export function getAdapter(
+  provider: string,
+  overrides?: Record<string, ProviderAdapter>,
+): ProviderAdapter {
+  return (
+    overrides?.[provider] ??
+    SPECIAL_ADAPTERS[provider] ??
+    openaiCompatible(provider)
+  );
+}

--- a/packages/gateway/src/resolve.ts
+++ b/packages/gateway/src/resolve.ts
@@ -1,0 +1,57 @@
+import type { ProviderAdapter } from './providers/types';
+import { DEFAULT_BASE_URLS, getAdapter } from './providers/registry';
+import { ok, type Result } from './result';
+import type { ProviderInput } from './types/config';
+import type { ProviderConfig } from './types/provider';
+import { type GatewayError, invalidRequest } from './utils/responses';
+
+const MODEL_RE = /^@([^/]+)\/(.+)$/;
+
+export interface ResolvedTarget {
+  adapter: ProviderAdapter;
+  config: ProviderConfig;
+  /** Bare model name (the `@slug/` prefix stripped). */
+  model: string;
+}
+
+/** Parse the `@slug/model` model string. */
+export function parseModel(
+  model: unknown,
+): Result<{ slug: string; model: string }, GatewayError> {
+  if (typeof model !== 'string' || model.length === 0) {
+    return invalidRequest('Request field "model" is required.');
+  }
+  const match = MODEL_RE.exec(model);
+  if (!match) {
+    return invalidRequest(
+      `Model "${model}" must be in "@provider-slug/model" format.`,
+    );
+  }
+  return ok({ slug: match[1], model: match[2] });
+}
+
+/** Resolve a slug to a provider target (adapter + config) using the gateway config. */
+export function resolveTarget(
+  slug: string,
+  model: string,
+  providers: Map<string, ProviderInput>,
+  adapters?: Record<string, ProviderAdapter>,
+): Result<ResolvedTarget, GatewayError> {
+  const input = providers.get(slug);
+  if (!input) {
+    return invalidRequest(`No provider configured for slug "@${slug}".`);
+  }
+  const baseURL = input.baseURL ?? DEFAULT_BASE_URLS[input.provider];
+  if (!baseURL) {
+    return invalidRequest(
+      `No base URL known for provider "${input.provider}" — pass "baseURL".`,
+    );
+  }
+  const config: ProviderConfig = {
+    provider: input.provider,
+    apiKey: input.apiKey,
+    baseURL,
+    forwardHeaders: input.forwardHeaders,
+  };
+  return ok({ adapter: getAdapter(input.provider, adapters), config, model });
+}

--- a/packages/gateway/src/router.ts
+++ b/packages/gateway/src/router.ts
@@ -1,0 +1,14 @@
+import { RequestType } from './types/requests';
+
+// Longest paths first so `/chat/completions` matches before `/completions`.
+const REQUEST_TYPES = Object.values(RequestType).sort(
+  (a, b) => b.length - a.length,
+);
+
+/**
+ * Match a request path to a RequestType. Tolerates any leading prefix (e.g.
+ * `/v1`, `/api/genai/v1`), so the plug works standalone or mounted.
+ */
+export function matchRoute(pathname: string): RequestType | null {
+  return REQUEST_TYPES.find((rt) => pathname.endsWith(rt)) ?? null;
+}

--- a/packages/gateway/src/types/config.ts
+++ b/packages/gateway/src/types/config.ts
@@ -1,0 +1,28 @@
+import type { ProviderAdapter } from '../providers/types';
+
+/**
+ * A provider the gateway can route to. OpenAI-compliant by default: give it a
+ * slug + apiKey and requests pass straight through. Providers that diverge from
+ * OpenAI are handled by registering a custom adapter (see GatewayConfig.adapters).
+ */
+export interface ProviderInput {
+  /** Provider id — selects the adapter and the default base URL (e.g. 'openai', 'groq'). */
+  provider: string;
+  /** Routing key used in the model string `@<slug>/<model>`. */
+  slug: string;
+  /** Upstream API key. */
+  apiKey?: string;
+  /** Override the upstream base URL (else the provider's known default). */
+  baseURL?: string;
+  /** Headers to forward as-is from the incoming request. */
+  forwardHeaders?: string[];
+}
+
+export interface GatewayConfig {
+  /** Providers this gateway can route to, resolved by slug from `@slug/model`. */
+  providers?: ProviderInput[];
+  /** Injected fetch (edge / testing). Defaults to globalThis.fetch. */
+  fetch?: typeof globalThis.fetch;
+  /** Custom adapters for non-OpenAI-compliant providers, keyed by provider id. */
+  adapters?: Record<string, ProviderAdapter>;
+}


### PR DESCRIPTION
**Step 2 of the gateway rewrite** — the plug now routes a real request. OpenAI-compliant by default (per the steer): any provider without a special adapter is treated as OpenAI-compatible pass-through; non-compliant providers (Anthropic, Bedrock, …) add deltas later via `config.adapters`.

## What
- `router.ts` — `matchRoute(path) → RequestType` (tolerates any prefix → works standalone or mounted).
- `resolve.ts` — parse `@slug/model`, resolve the provider config (base URL + auth).
- `providers/openai-compatible.ts` — the **default adapter**: pure pass-through, Bearer auth, body untouched.
- `providers/registry.ts` — `getAdapter()` (OpenAI-compatible by default) + default base URLs for ~9 known providers.
- `execute.ts` — build the upstream request, `fetch`, return the response **as-is** (stream included).
- `gateway.ts` — `createGateway(config)` wires it: route → resolve → strip `@slug/` → fetch.

```ts
const gw = createGateway({
  providers: [{ provider: 'openai', slug: 'openai', apiKey: process.env.OPENAI_API_KEY }],
})
await gw(new Request('http://x/v1/chat/completions', {
  method: 'POST',
  body: JSON.stringify({ model: '@openai/gpt-4o', messages }),
}))
```

## Verify
- `@llmops/gateway` typecheck + build ✅ green; bundle **9.2 KB (3.25 KB gzip), zero deps**.
- **6 mock-fetch tests** ✅ — upstream URL, Bearer auth, `@slug/` model-strip, response pass-through, 400 (bad model / unknown slug), 404 (bad path). Run: `pnpm --filter @llmops/gateway test`.

## Not in this step
Telemetry/cost (Step 4), Anthropic-native `/v1/messages` (Step 3), mounting into the app (still 503 until wired). Gateway package only.

Base `v1.0.0`.
