### PR TITLE
feat(core): provider routing metadata + getProviderMetadata / getModelPricing

### DIFF
--- a/packages/core/src/pricing/index.ts
+++ b/packages/core/src/pricing/index.ts
@@ -49,3 +49,6 @@ export {
   LLMOpsPricingProvider,
   getDefaultPricingProvider,
 } from './provider';
+
+// Default model-pricing resolver (config-overridable via getModelPricing)
+export { getModelPricing } from './resolver';

--- a/packages/core/src/pricing/resolver.ts
+++ b/packages/core/src/pricing/resolver.ts
@@ -1,0 +1,17 @@
+import { getDefaultPricingProvider } from './provider';
+import type { ModelPricing } from './types';
+
+/**
+ * Default model-pricing resolver — fetches pricing from models.llmops.build and
+ * caches it (TTL / dedupe / stale-fallback, via the default pricing provider).
+ *
+ * The sibling of `getProviderMetadata`. Unlike provider metadata (bundled),
+ * pricing is fetched at runtime: it's dynamic, large, and off the routing hot
+ * path. Override via `llmops({ getModelPricing })`.
+ */
+export function getModelPricing(
+  provider: string,
+  model: string,
+): Promise<ModelPricing | null> {
+  return getDefaultPricingProvider().getModelPricing(provider, model);
+}

--- a/packages/core/src/providers/index.ts
+++ b/packages/core/src/providers/index.ts
@@ -32,3 +32,10 @@ export {
   mergeWithDefaultProviders,
   DEFAULT_PROVIDER_ENV_VARS,
 } from './default-providers';
+
+// Provider routing metadata + default resolver (config-overridable via getProviderMetadata)
+export {
+  getProviderMetadata,
+  PROVIDER_METADATA,
+  type ProviderMetadata,
+} from './metadata';

--- a/packages/core/src/providers/metadata.test.ts
+++ b/packages/core/src/providers/metadata.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { getProviderMetadata, PROVIDER_METADATA } from './metadata';
+
+describe('getProviderMetadata', () => {
+  it('returns baseURL + compat for a known OpenAI-compatible provider', async () => {
+    expect(await getProviderMetadata('groq')).toEqual({
+      baseURL: 'https://api.groq.com/openai/v1',
+      openaiCompatible: true,
+    });
+  });
+
+  it('flags divergent providers as not OpenAI-compatible', async () => {
+    expect((await getProviderMetadata('anthropic'))?.openaiCompatible).toBe(
+      false,
+    );
+    expect((await getProviderMetadata('bedrock'))?.openaiCompatible).toBe(false);
+  });
+
+  it('returns null for an uncurated / unknown provider', async () => {
+    expect(await getProviderMetadata('does-not-exist')).toBeNull();
+  });
+
+  it('every entry declares a boolean openaiCompatible', () => {
+    for (const [name, meta] of Object.entries(PROVIDER_METADATA)) {
+      expect(typeof meta.openaiCompatible, name).toBe('boolean');
+    }
+  });
+});

--- a/packages/core/src/providers/metadata.ts
+++ b/packages/core/src/providers/metadata.ts
@@ -1,0 +1,116 @@
+/**
+ * Provider routing metadata — base URL + OpenAI-compatibility per provider.
+ *
+ * This is deliberately BUNDLED (not fetched at runtime): it's tiny, effectively
+ * never changes, and sits on the routing hot path, so it must not depend on a
+ * network call (a cold start, an edge deploy, or a models.llmops.build blip must
+ * never block routing). Pricing — which is dynamic, large, and off the hot path
+ * — stays a live fetch (see `getModelPricing`).
+ *
+ * `getProviderMetadata` is the default resolver. Override it via
+ * `llmops({ getProviderMetadata })` to self-host, air-gap, or point at a live
+ * endpoint.
+ *
+ * This is a curated bootstrap covering the common providers. The authoritative
+ * source is the `llmops-build/models` repo — this table will be generated from
+ * it at build time (keys match the `general/*.json` filenames).
+ */
+export interface ProviderMetadata {
+  /**
+   * Upstream base URL. Omitted for providers whose URL isn't static — Bedrock,
+   * Vertex, Azure are region/resource-scoped, so they require an explicit
+   * `baseURL` at call time.
+   */
+  baseURL?: string;
+  /**
+   * Whether the provider speaks the OpenAI wire format. `false` providers
+   * (Anthropic, Google, Bedrock, …) need a dedicated adapter in the gateway.
+   */
+  openaiCompatible: boolean;
+}
+
+/** Curated provider metadata, keyed by provider id (the `llmops-build/models` filename). */
+export const PROVIDER_METADATA: Record<string, ProviderMetadata> = {
+  // ── OpenAI-compatible (pass-through) ─────────────────────────────────
+  openai: { baseURL: 'https://api.openai.com/v1', openaiCompatible: true },
+  groq: { baseURL: 'https://api.groq.com/openai/v1', openaiCompatible: true },
+  'mistral-ai': { baseURL: 'https://api.mistral.ai/v1', openaiCompatible: true },
+  'together-ai': { baseURL: 'https://api.together.xyz/v1', openaiCompatible: true },
+  'fireworks-ai': {
+    baseURL: 'https://api.fireworks.ai/inference/v1',
+    openaiCompatible: true,
+  },
+  deepseek: { baseURL: 'https://api.deepseek.com', openaiCompatible: true },
+  openrouter: {
+    baseURL: 'https://openrouter.ai/api/v1',
+    openaiCompatible: true,
+  },
+  'x-ai': { baseURL: 'https://api.x.ai/v1', openaiCompatible: true },
+  cerebras: { baseURL: 'https://api.cerebras.ai/v1', openaiCompatible: true },
+  sambanova: { baseURL: 'https://api.sambanova.ai/v1', openaiCompatible: true },
+  deepinfra: {
+    baseURL: 'https://api.deepinfra.com/v1/openai',
+    openaiCompatible: true,
+  },
+  'perplexity-ai': {
+    baseURL: 'https://api.perplexity.ai',
+    openaiCompatible: true,
+  },
+  nebius: {
+    baseURL: 'https://api.studio.nebius.ai/v1',
+    openaiCompatible: true,
+  },
+  'novita-ai': {
+    baseURL: 'https://api.novita.ai/v3/openai',
+    openaiCompatible: true,
+  },
+  moonshot: { baseURL: 'https://api.moonshot.ai/v1', openaiCompatible: true },
+  ai21: { baseURL: 'https://api.ai21.com/studio/v1', openaiCompatible: true },
+  jina: { baseURL: 'https://api.jina.ai/v1', openaiCompatible: true },
+  'inference-net': {
+    baseURL: 'https://api.inference.net/v1',
+    openaiCompatible: true,
+  },
+  upstage: { baseURL: 'https://api.upstage.ai/v1', openaiCompatible: true },
+  nscale: {
+    baseURL: 'https://inference.api.nscale.com/v1',
+    openaiCompatible: true,
+  },
+  'lemonfox-ai': {
+    baseURL: 'https://api.lemonfox.ai/v1',
+    openaiCompatible: true,
+  },
+
+  // ── Divergent — need a dedicated adapter (not OpenAI wire format) ─────
+  anthropic: { baseURL: 'https://api.anthropic.com', openaiCompatible: false },
+  google: {
+    baseURL: 'https://generativelanguage.googleapis.com',
+    openaiCompatible: false,
+  },
+  cohere: { baseURL: 'https://api.cohere.com', openaiCompatible: false },
+  palm: { openaiCompatible: false },
+  bedrock: { openaiCompatible: false },
+  'bedrock-mantle': { openaiCompatible: false },
+  'claude-platform-aws': { openaiCompatible: false },
+  'vertex-ai': { openaiCompatible: false },
+  'azure-ai': { openaiCompatible: false },
+  'azure-openai': { openaiCompatible: false },
+  replicate: { openaiCompatible: false },
+
+  // ── Non-chat (image / media) — not OpenAI chat-compatible ────────────
+  'stability-ai': { openaiCompatible: false },
+  'fal-ai': { openaiCompatible: false },
+  segmind: { openaiCompatible: false },
+};
+
+/**
+ * Default provider-metadata resolver — reads the bundled table above. Async to
+ * match the injectable `getProviderMetadata` config signature (an override may
+ * fetch from a network source). Returns `null` for providers not yet curated;
+ * such providers are still routable if the caller supplies an explicit baseURL.
+ */
+export function getProviderMetadata(
+  provider: string,
+): Promise<ProviderMetadata | null> {
+  return Promise.resolve(PROVIDER_METADATA[provider] ?? null);
+}


### PR DESCRIPTION
Adds the two config-overridable metadata resolvers we designed — the data layer the gateway's routing (and cost) will read from.

## What
- **`getProviderMetadata(provider) → { baseURL, openaiCompatible }`** — reads a **bundled** table (`providers/metadata.ts`). Provider routing metadata is tiny, ~never changes, and is on the **routing hot path**, so it must not depend on a network call (a cold start / edge deploy / models.llmops.build blip must never block routing). Curated bootstrap of the common providers, keyed by the `llmops-build/models` `general/` filenames; **OpenAI-compatible by default**, the divergent ones (`anthropic`, `google`, `bedrock*`, `vertex-ai`, `azure*`, `cohere`, image/media) flagged `false`.
- **`getModelPricing(provider, model) → ModelPricing | null`** — thin wrapper over the existing pricing provider (fetches `models.llmops.build` + caches). Pricing is **dynamic and off the hot path**, so it stays a live fetch.

Both are exported from `@llmops/core` and are the injectable defaults for the future `llmops({ getProviderMetadata, getModelPricing })` config.

## Why bundle one and fetch the other
Different data, different strategy: routing metadata = static/tiny/hot-path → **bundle**; pricing = dynamic/large/off-path → **fetch**. Users override either with their own function (self-host / air-gap / DB).

## Verify
- `@llmops/core` typecheck + build ✅ green
- **4 tests** (`metadata.test.ts`) ✅ — known compat provider, divergent flag, null for uncurated, every entry declares `openaiCompatible`. Run: `pnpm --filter @llmops/core exec vitest run src/providers/metadata.test.ts`

## Notes / next
- The table is a **curated bootstrap** — accurate for the popular providers, `null` for the long tail (still routable with an explicit `baseURL`). It'll be **generated from `llmops-build/models`** at build time as the SSOT (the fast-follow), keeping "provider metadata comes from models.llmops.build" true.
- Next: wire both into `llmops()` config + have the gateway's `resolve()` call `getProviderMetadata` (replacing the hardcoded `DEFAULT_BASE_URLS`).

Base `v1.0.0`.
