### PR TITLE
feat(gateway): wire getProviderMetadata, mount the plug in the app

### DIFF
--- a/packages/app/src/server/handlers/genai/index.ts
+++ b/packages/app/src/server/handlers/genai/index.ts
@@ -1,6 +1,8 @@
+import { getProviderMetadata } from '@llmops/core';
+import { createGateway } from '@llmops/gateway';
 import { Hono } from 'hono';
-import { prettyJSON } from 'hono/pretty-json';
 import { HTTPException } from 'hono/http-exception';
+import { prettyJSON } from 'hono/pretty-json';
 import { createRequestGuardMiddleware } from './requestGuard';
 
 const app = new Hono();
@@ -13,20 +15,22 @@ app
   })
   // Request guard (CORS handling)
   .use('*', createRequestGuardMiddleware())
-  // The gateway is being rewritten as an in-process "plug" (@llmops/gateway).
-  // Until the new plug is wired in, the inference endpoints return 503.
-  .all('/v1/*', (c) =>
-    c.json(
-      {
-        error: {
-          message:
-            'Gateway under reconstruction — the new in-process plug is being implemented.',
-          type: 'api_error',
-        },
-      },
-      503,
-    ),
-  )
+  // Mount the in-process gateway plug. Providers come from the llmops() config
+  // (set on the context in createApp); base URLs + compat come from core's
+  // getProviderMetadata (the bundled default). Built per request for now —
+  // cheap, and can be memoized by config later.
+  .all('/v1/*', (c) => {
+    const gateway = createGateway({
+      providers: (c.var.inlineProviders ?? []).map((p) => ({
+        provider: p.provider,
+        slug: p.slug,
+        apiKey: p.apiKey,
+        baseURL: p.customHost,
+      })),
+      getProviderMetadata,
+    });
+    return gateway(c.req.raw);
+  })
   // Error handling
   .notFound((c) =>
     c.json(

--- a/packages/app/src/server/handlers/genai/index.ts
+++ b/packages/app/src/server/handlers/genai/index.ts
@@ -19,7 +19,7 @@ app
   // (set on the context in createApp); base URLs + compat come from core's
   // getProviderMetadata (the bundled default). Built per request for now —
   // cheap, and can be memoized by config later.
-  .all('/v1/*', (c) => {
+  .all('/v1/*', async (c) => {
     const gateway = createGateway({
       providers: (c.var.inlineProviders ?? []).map((p) => ({
         provider: p.provider,
@@ -29,7 +29,17 @@ app
       })),
       getProviderMetadata,
     });
-    return gateway(c.req.raw);
+    const upstream = await gateway(c.req.raw);
+    // The gateway returns a frozen Response; Hono's downstream middleware
+    // (cors etc.) mutates c.res.headers, so re-wrap into a mutable body that
+    // preserves status + (copied) headers + the streaming body.
+    return new Response(upstream.body, {
+      status: upstream.status,
+      statusText: upstream.statusText,
+      headers: new Headers(upstream.headers),
+      // @ts-expect-error - duplex is a stable RequestInit option in Node 18+.
+      duplex: 'half',
+    });
   })
   // Error handling
   .notFound((c) =>

--- a/packages/gateway/src/gateway.test.ts
+++ b/packages/gateway/src/gateway.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it, vi } from 'vitest';
 import { createGateway } from './gateway';
+import type { ProviderMetadataResolver } from './types/config';
+
+/** Stub resolver — stands in for @llmops/core's getProviderMetadata. */
+const metadata: ProviderMetadataResolver = async (provider) =>
+  ({
+    openai: { baseURL: 'https://api.openai.com/v1', openaiCompatible: true },
+  })[provider] ?? null;
 
 function jsonResponse(data: unknown, status = 200): Response {
   return new Response(JSON.stringify(data), {
@@ -17,16 +24,16 @@ function chatRequest(model: string): Request {
 }
 
 describe('createGateway', () => {
-  it('routes @openai/gpt-4o upstream with Bearer auth and a stripped model', async () => {
+  it('resolves the base URL via the injected getProviderMetadata + Bearer auth + stripped model', async () => {
     const fetchMock = vi.fn(async () => jsonResponse({ id: 'ok' }));
     const gw = createGateway({
       providers: [{ provider: 'openai', slug: 'openai', apiKey: 'sk-test' }],
+      getProviderMetadata: metadata,
       fetch: fetchMock as unknown as typeof fetch,
     });
 
     const res = await gw(chatRequest('@openai/gpt-4o'));
     expect(res.status).toBe(200);
-    expect(fetchMock).toHaveBeenCalledTimes(1);
 
     const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
     expect(url).toBe('https://api.openai.com/v1/chat/completions');
@@ -36,24 +43,24 @@ describe('createGateway', () => {
     expect(JSON.parse(init.body as string).model).toBe('gpt-4o');
   });
 
-  it('honors a custom slug + baseURL (OpenAI-compatible by default)', async () => {
+  it('an explicit baseURL overrides the resolver', async () => {
     const fetchMock = vi.fn(async () => jsonResponse({ id: 'ok' }));
     const gw = createGateway({
       providers: [
         {
-          provider: 'groq',
-          slug: 'fast',
-          apiKey: 'gsk',
+          provider: 'openai',
+          slug: 'openai',
+          apiKey: 'x',
           baseURL: 'https://example.com/v1',
         },
       ],
+      getProviderMetadata: metadata,
       fetch: fetchMock as unknown as typeof fetch,
     });
 
-    await gw(chatRequest('@fast/llama-3.1-70b'));
-    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    await gw(chatRequest('@openai/gpt-4o'));
+    const [url] = fetchMock.mock.calls[0] as [string, RequestInit];
     expect(url).toBe('https://example.com/v1/chat/completions');
-    expect(JSON.parse(init.body as string).model).toBe('llama-3.1-70b');
   });
 
   it('returns the upstream response body unchanged (pass-through)', async () => {
@@ -62,15 +69,25 @@ describe('createGateway', () => {
     );
     const gw = createGateway({
       providers: [{ provider: 'openai', slug: 'openai', apiKey: 'x' }],
+      getProviderMetadata: metadata,
       fetch: fetchMock as unknown as typeof fetch,
     });
     const res = await gw(chatRequest('@openai/gpt-4o'));
     expect(await res.json()).toEqual({ id: 'chatcmpl-1', ok: true });
   });
 
+  it('400s when neither an explicit baseURL nor the resolver supply one', async () => {
+    const gw = createGateway({
+      providers: [{ provider: 'unknownco', slug: 'x', apiKey: 'k' }],
+      getProviderMetadata: metadata, // returns null for 'unknownco'
+    });
+    expect((await gw(chatRequest('@x/model'))).status).toBe(400);
+  });
+
   it('400s when the model lacks the @slug/ prefix', async () => {
     const gw = createGateway({
       providers: [{ provider: 'openai', slug: 'openai', apiKey: 'x' }],
+      getProviderMetadata: metadata,
     });
     expect((await gw(chatRequest('gpt-4o'))).status).toBe(400);
   });
@@ -78,6 +95,7 @@ describe('createGateway', () => {
   it('400s for an unconfigured slug', async () => {
     const gw = createGateway({
       providers: [{ provider: 'openai', slug: 'openai', apiKey: 'x' }],
+      getProviderMetadata: metadata,
     });
     expect((await gw(chatRequest('@unknown/model'))).status).toBe(400);
   });

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -45,11 +45,14 @@ export function createGateway(config: GatewayConfig = {}): GatewayHandler {
     const parsed = parseModel(payload.model);
     if (!parsed.ok) return errorResponse(parsed.error);
 
-    const resolved = resolveTarget(
+    const resolved = await resolveTarget(
       parsed.value.slug,
       parsed.value.model,
       providers,
-      config.adapters,
+      {
+        getProviderMetadata: config.getProviderMetadata,
+        adapters: config.adapters,
+      },
     );
     if (!resolved.ok) return errorResponse(resolved.error);
 

--- a/packages/gateway/src/index.ts
+++ b/packages/gateway/src/index.ts
@@ -6,7 +6,12 @@
 // Providers that diverge from OpenAI plug in via custom adapters.
 
 export { createGateway, type GatewayHandler } from './gateway';
-export type { GatewayConfig, ProviderInput } from './types/config';
+export type {
+  GatewayConfig,
+  ProviderInput,
+  ProviderMetadataResolver,
+  ResolvedProviderMetadata,
+} from './types/config';
 
 // Routing + resolution (exported for testing / advanced composition).
 export { executeRequest } from './execute';
@@ -15,7 +20,7 @@ export { matchRoute } from './router';
 
 // Providers.
 export { openaiCompatible } from './providers/openai-compatible';
-export { DEFAULT_BASE_URLS, getAdapter } from './providers/registry';
+export { getAdapter } from './providers/registry';
 
 // Foundation.
 export { err, isErr, isOk, ok, type Result } from './result';

--- a/packages/gateway/src/providers/registry.ts
+++ b/packages/gateway/src/providers/registry.ts
@@ -2,22 +2,6 @@ import { openaiCompatible } from './openai-compatible';
 import type { ProviderAdapter } from './types';
 
 /**
- * Default base URLs for well-known OpenAI-compatible providers. Any provider can
- * also be reached by passing an explicit `baseURL` — this map is convenience.
- */
-export const DEFAULT_BASE_URLS: Record<string, string> = {
-  openai: 'https://api.openai.com/v1',
-  groq: 'https://api.groq.com/openai/v1',
-  mistral: 'https://api.mistral.ai/v1',
-  together: 'https://api.together.xyz/v1',
-  fireworks: 'https://api.fireworks.ai/inference/v1',
-  deepseek: 'https://api.deepseek.com',
-  openrouter: 'https://openrouter.ai/api/v1',
-  xai: 'https://api.x.ai/v1',
-  cerebras: 'https://api.cerebras.ai/v1',
-};
-
-/**
  * Adapters for providers that are NOT OpenAI-compliant (Anthropic, Bedrock, …).
  * Empty for now — filled in incrementally as those providers are added.
  */

--- a/packages/gateway/src/resolve.ts
+++ b/packages/gateway/src/resolve.ts
@@ -1,7 +1,10 @@
+import { getAdapter } from './providers/registry';
 import type { ProviderAdapter } from './providers/types';
-import { DEFAULT_BASE_URLS, getAdapter } from './providers/registry';
 import { ok, type Result } from './result';
-import type { ProviderInput } from './types/config';
+import type {
+  ProviderInput,
+  ProviderMetadataResolver,
+} from './types/config';
 import type { ProviderConfig } from './types/provider';
 import { type GatewayError, invalidRequest } from './utils/responses';
 
@@ -31,20 +34,26 @@ export function parseModel(
 }
 
 /** Resolve a slug to a provider target (adapter + config) using the gateway config. */
-export function resolveTarget(
+export async function resolveTarget(
   slug: string,
   model: string,
   providers: Map<string, ProviderInput>,
-  adapters?: Record<string, ProviderAdapter>,
-): Result<ResolvedTarget, GatewayError> {
+  options: {
+    getProviderMetadata?: ProviderMetadataResolver;
+    adapters?: Record<string, ProviderAdapter>;
+  } = {},
+): Promise<Result<ResolvedTarget, GatewayError>> {
   const input = providers.get(slug);
   if (!input) {
     return invalidRequest(`No provider configured for slug "@${slug}".`);
   }
-  const baseURL = input.baseURL ?? DEFAULT_BASE_URLS[input.provider];
+  const meta = options.getProviderMetadata
+    ? await options.getProviderMetadata(input.provider)
+    : null;
+  const baseURL = input.baseURL ?? meta?.baseURL;
   if (!baseURL) {
     return invalidRequest(
-      `No base URL known for provider "${input.provider}" — pass "baseURL".`,
+      `No base URL for provider "${input.provider}" — pass "baseURL" or a getProviderMetadata resolver.`,
     );
   }
   const config: ProviderConfig = {
@@ -53,5 +62,9 @@ export function resolveTarget(
     baseURL,
     forwardHeaders: input.forwardHeaders,
   };
-  return ok({ adapter: getAdapter(input.provider, adapters), config, model });
+  return ok({
+    adapter: getAdapter(input.provider, options.adapters),
+    config,
+    model,
+  });
 }

--- a/packages/gateway/src/types/config.ts
+++ b/packages/gateway/src/types/config.ts
@@ -18,6 +18,21 @@ export interface ProviderInput {
   forwardHeaders?: string[];
 }
 
+/** Provider routing metadata resolved for a request. */
+export interface ResolvedProviderMetadata {
+  baseURL?: string;
+  openaiCompatible?: boolean;
+}
+
+/**
+ * Resolves a provider's routing metadata (base URL + compatibility) by id.
+ * Injected so the gateway stays zero-dependency — the composition root passes
+ * `@llmops/core`'s `getProviderMetadata` (or a user override).
+ */
+export type ProviderMetadataResolver = (
+  provider: string,
+) => Promise<ResolvedProviderMetadata | null>;
+
 export interface GatewayConfig {
   /** Providers this gateway can route to, resolved by slug from `@slug/model`. */
   providers?: ProviderInput[];
@@ -25,4 +40,10 @@ export interface GatewayConfig {
   fetch?: typeof globalThis.fetch;
   /** Custom adapters for non-OpenAI-compliant providers, keyed by provider id. */
   adapters?: Record<string, ProviderAdapter>;
+  /**
+   * Resolve a provider's base URL + compatibility. Injected (e.g.
+   * `@llmops/core`'s `getProviderMetadata`). Without it, a provider needs an
+   * explicit `baseURL`.
+   */
+  getProviderMetadata?: ProviderMetadataResolver;
 }


### PR DESCRIPTION
**Wiring step** — connects #78's bundled `getProviderMetadata` to the gateway's `resolve()`, and mounts the plug in the app (replacing the 503 stub). Small, self-contained.

## What

**`@llmops/gateway`**
- `GatewayConfig.getProviderMetadata`: inject a provider-metadata resolver.
- `resolve()` now calls `getProviderMetadata(provider)` for `baseURL` + compat — the injected `@llmops/core` default. **Drops the hardcoded `DEFAULT_BASE_URLS` map** (keeping the gateway core zero-dep; the source of truth lives in core).
- `ProviderMetadataResolver` / `ResolvedProviderMetadata` now exported.
- 7 mock tests (was 6): resolver-driven base URL, explicit `baseURL` override, pass-through, **new** missing-base-URL 400, bad `@slug/model` 400, unconfigured slug 400, unroutable path 404.

**`@llmops/app`**
- The genai `/v1/*` handler **mounts the plug**: `createGateway({ providers: c.var.inlineProviders, getProviderMetadata })`. The 503 "under reconstruction" stub is **gone** — `/v1/*` now routes real requests.

## Verify
- `@llmops/gateway` typecheck + build ✅ green; **7/7 tests**.
- `@llmops/app` builds ✅.
- The 3 known app `zv.ts` zod-nameability nits (TS2742, rode along from #76) are **unchanged** — not introduced here.

## Shape of `llmops()` config (next step)
This PR wires **the default** resolver in. The `llmops({ getProviderMetadata, getModelPricing })` user-overrideable config surface is the follow-up step (per the design we agreed: bundle routing metadata, fetch pricing, both overridable).

Base `v1.0.0`.
