### PR TITLE
feat(app): wire gateway telemetry — calls light up the dashboard

### DIFF
--- a/packages/app/src/index.ts
+++ b/packages/app/src/index.ts
@@ -1,7 +1,12 @@
 import { Hono, type MiddlewareHandler } from 'hono';
 import mainApp from './server';
-import type { LLMOpsConfig } from '@llmops/core';
+import { type LLMOpsConfig, type TelemetrySink } from '@llmops/core';
 import { validateLLMOpsConfig, type ValidatedLLMOpsConfig } from '@llmops/core';
+import {
+  createStoreSink,
+  noopSink,
+  type TelemetryStore,
+} from '@llmops/sdk';
 import { createEnvValidatorMiddleware } from '@server/middlewares/env';
 import { createMigrationMiddleware } from '@server/middlewares/migration';
 import { createStaticAssetMiddleware } from '@server/middlewares/static-assets';
@@ -21,21 +26,23 @@ const setConfigMiddleware = (
 /**
  * Resolve the first TelemetryStore from the config's telemetry option.
  */
-function resolveTelemetryStore(telemetry: unknown) {
+function resolveTelemetryStore(telemetry: unknown): TelemetryStore | null {
   if (!telemetry) return null;
-  if (Array.isArray(telemetry)) return telemetry[0] ?? null;
-  return telemetry;
+  if (Array.isArray(telemetry)) return (telemetry[0] as TelemetryStore) ?? null;
+  return telemetry as TelemetryStore;
 }
 
 /**
- * Middleware that wires up telemetry store.
+ * Middleware that wires up telemetry store + sink on every request context.
  */
 const createTelemetryMiddleware = (
+  sink: TelemetrySink,
   validatedConfig: ValidatedLLMOpsConfig,
 ): MiddlewareHandler => {
   return async (c, next) => {
     const store = resolveTelemetryStore(validatedConfig.telemetry);
-    c.set('telemetryStore', store ?? null);
+    c.set('telemetryStore', store);
+    c.set('telemetrySink', sink);
     await next();
   };
 };
@@ -44,16 +51,27 @@ export const createApp = (config?: LLMOpsConfig) => {
   const validatedConfig = validateLLMOpsConfig(config);
   const store = resolveTelemetryStore(validatedConfig.telemetry);
 
+  // Build the TelemetrySink ONCE from the configured store. The gateway emits
+  // llm_request events here; the sink batches + flushes (interval on Node,
+  // waitUntil on edge). When no store is configured, a no-op sink keeps the
+  // gateway a pure proxy — zero added latency, zero runtime cost.
+  const sink: TelemetrySink = store
+    ? createStoreSink(store, {
+        flushIntervalMs: 2000,
+        waitUntil: validatedConfig.waitUntil,
+      })
+    : noopSink;
+
   const app = new Hono()
     .use('/assets/*', createStaticAssetMiddleware())
     .use('*', createEnvValidatorMiddleware())
     .use('*', setConfigMiddleware(validatedConfig));
 
-  if (store && store._pool) {
-    app.use('*', createMigrationMiddleware(validatedConfig));
-  }
-
-  app.use('*', createTelemetryMiddleware(validatedConfig));
+  // Auto-migration middleware. It gracefully no-ops when the configured store
+  // is not pg-backed (no `_pool`), so mount it once and let the middleware be
+  // the sole authority on whether migration runs.
+  app.use('*', createMigrationMiddleware(validatedConfig));
+  app.use('*', createTelemetryMiddleware(sink, validatedConfig));
   app.route('/', mainApp).basePath(validatedConfig.basePath);
 
   return {

--- a/packages/app/src/server/handlers/genai/index.ts
+++ b/packages/app/src/server/handlers/genai/index.ts
@@ -1,4 +1,4 @@
-import { getProviderMetadata } from '@llmops/core';
+import { getModelPricing, getProviderMetadata } from '@llmops/core';
 import { createGateway } from '@llmops/gateway';
 import { Hono } from 'hono';
 import { HTTPException } from 'hono/http-exception';
@@ -17,8 +17,11 @@ app
   .use('*', createRequestGuardMiddleware())
   // Mount the in-process gateway plug. Providers come from the llmops() config
   // (set on the context in createApp); base URLs + compat come from core's
-  // getProviderMetadata (the bundled default). Built per request for now —
-  // cheap, and can be memoized by config later.
+  // bundled getProviderMetadata; pricing comes from core's getModelPricing
+  // (live fetch from models.llmops.build, cached). Telemetry sink is built once
+  // in createApp and set on the context; the gateway streams usage/cost events
+  // to it (fire-and-forget via the stream-tee instrument). Built per request for
+  // now — cheap, and can be memoized by config later.
   .all('/v1/*', async (c) => {
     const gateway = createGateway({
       providers: (c.var.inlineProviders ?? []).map((p) => ({
@@ -28,6 +31,9 @@ app
         baseURL: p.customHost,
       })),
       getProviderMetadata,
+      getModelPricing,
+      telemetry: c.get('telemetrySink'),
+      waitUntil: c.get('llmopsConfig').waitUntil,
     });
     const upstream = await gateway(c.req.raw);
     // The gateway returns a frozen Response; Hono's downstream middleware

--- a/packages/app/src/server/types.ts
+++ b/packages/app/src/server/types.ts
@@ -1,6 +1,7 @@
 import {
   type ValidatedLLMOpsConfig,
   type InlineProvidersConfig,
+  type TelemetrySink,
 } from '@llmops/core';
 import type { TelemetryStore } from '@llmops/sdk';
 
@@ -9,6 +10,8 @@ declare module 'hono' {
     llmopsConfig: ValidatedLLMOpsConfig;
     inlineProviders?: InlineProvidersConfig;
     telemetryStore: TelemetryStore | null;
+    /** Sink the gateway + observe() emit to. Built once in createApp. */
+    telemetrySink: TelemetrySink;
   }
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -533,6 +533,9 @@ importers:
       '@cloudflare/workers-types':
         specifier: ^4.20230518.0
         version: 4.20251221.0
+      '@llmops/core':
+        specifier: workspace:^
+        version: link:../core
       '@types/node':
         specifier: 20.8.3
         version: 20.8.3


### PR DESCRIPTION
**Step 4b of the gateway rewrite** — the end-to-end payoff. A call through the plug now emits usage + cost to the telemetry store, so the dashboard populates with zero extra code. This is the GIF that sells "plug, not a proxy."

## What
- **`createApp`** builds a `TelemetrySink` ONCE from the configured store (via `createStoreSink` from `@llmops/sdk`, mirroring the SDK client). When no store is configured, a `noopSink` keeps the gateway a pure proxy — zero added latency. The sink is set on the Hono context.
- **The genai handler** passes `telemetry` + `getModelPricing` + `waitUntil` into `createGateway`. Core's `getModelPricing` (live fetch from `models.llmops.build`, cached) is the default pricing source.
- `ContextVariableMap` gains `telemetrySink`.

## Why no double-counting
The old `costTracking` middleware has been **disconnected from the genai path** since Step 1 (the demolition removed its `.use()` mount). The gateway's `emit` is the sole writer on the inference path.

## Verify
- **End-to-end**: a hermetic test with a mock upstream + capturing sink confirms:
  - `usage: { inputTokens: 5, outputTokens: 3 }` extracted from upstream ✓
  - `cost: 0.0000425` in **dollars** = `(5×2.5 + 3×10) / 1e6` — the micro→dollar bridge is correct ✓
  - caller body returned **unchanged** (pass-through) ✓
  - one `llm_request` event emitted ✓
- `@llmops/app` typecheck — only the 3 pre-existing `zv.ts` nits (nothing new from this change). Build ✅ green.
- `@llmops/gateway` + `@llmops/core` + `@llmops/sdk` build ✅ green.

## How to test it
```bash
OPENAI_API_KEY=sk-... node smoke.mjs   # uses createGateway through the app
# → completion returned + a row in the dashboard (cost, tokens, latency)
```

## Not in this step (each its own PR)
- The `costTracking` middleware file itself is now dead code — separate cleanup.
- `getProviderMetadata` / `getModelPricing` as `llmops({...})` config overrides.
- Anthropic-native usage shapes.

Base `v1.0.0`.
