### PR TITLE
feat(gateway): emit automatic traces for model calls

### DIFF
--- a/packages/core/src/telemetry/events.ts
+++ b/packages/core/src/telemetry/events.ts
@@ -36,6 +36,8 @@ export interface LLMRequestRecord {
   /** Computed cost in USD. */
   cost?: number;
   latencyMs?: number;
+  /** Whether the upstream response was delivered as a stream. */
+  isStreaming?: boolean;
   status: 'success' | 'error';
   error?: string;
   tags?: Record<string, string>;

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -2,6 +2,7 @@ import { executeRequest } from './execute';
 import { instrumentResponse } from './instrument';
 import { parseModel, resolveTarget } from './resolve';
 import { matchRoute } from './router';
+import { resolveGatewayTraceContext } from './trace-context';
 import type { GatewayConfig, ProviderInput } from './types/config';
 import { errorResponse } from './utils/responses';
 
@@ -23,6 +24,8 @@ export function createGateway(config: GatewayConfig = {}): GatewayHandler {
 
   return async (req) => {
     const startMs = Date.now();
+    const requestId = crypto.randomUUID();
+    const trace = resolveGatewayTraceContext(req.headers);
     const pathname = new URL(req.url).pathname;
     const requestType = matchRoute(pathname);
     if (!requestType) {
@@ -88,12 +91,14 @@ export function createGateway(config: GatewayConfig = {}): GatewayHandler {
       telemetry: config.telemetry,
       getModelPricing: config.getModelPricing,
       waitUntil: config.waitUntil,
-      requestId: crypto.randomUUID(),
+      requestId,
+      trace,
       provider: resolved.value.config.provider,
       model: parsed.value.model,
       input: payload,
       startedAt: new Date(startMs).toISOString(),
       startMs,
+      isStreaming: rewritten.stream === true,
     });
   };
 }

--- a/packages/gateway/src/instrument.test.ts
+++ b/packages/gateway/src/instrument.test.ts
@@ -77,7 +77,7 @@ describe('gateway telemetry', () => {
     expect((await res.json()).choices[0].message.content).toBe('hey');
 
     await h.settle();
-    expect(h.events).toHaveLength(1);
+    expect(h.events).toHaveLength(2);
     const { type, request } = h.events[0];
     expect(type).toBe('llm_request');
     expect(request.provider).toBe('openai');
@@ -87,6 +87,23 @@ describe('gateway telemetry', () => {
     expect(request.cost).toBeCloseTo(0.0075);
     expect(request.status).toBe('success');
     expect(typeof request.latencyMs).toBe('number');
+    expect(request.traceId).toMatch(/^[0-9a-f]{32}$/);
+    expect(request.spanId).toMatch(/^[0-9a-f]{16}$/);
+    expect(res.headers.get('x-llmops-trace-id')).toBe(request.traceId);
+    expect(res.headers.get('x-llmops-span-id')).toBe(request.spanId);
+
+    const spanEvent = h.events[1];
+    expect(spanEvent.type).toBe('span');
+    expect(spanEvent.span).toMatchObject({
+      traceId: request.traceId,
+      spanId: request.spanId,
+      status: 'ok',
+      kind: 'server',
+    });
+    expect(spanEvent.trace).toMatchObject({
+      traceId: request.traceId,
+      status: 'ok',
+    });
   });
 
   it('streaming: caller gets the full stream, one event from the terminal usage chunk', async () => {
@@ -118,13 +135,15 @@ describe('gateway telemetry', () => {
     expect(await res.text()).toBe(chunks.join('')); // caller received every byte
 
     await h.settle();
-    expect(h.events).toHaveLength(1);
+    expect(h.events).toHaveLength(2);
     expect(h.events[0].request.usage).toMatchObject({
       inputTokens: 100,
       outputTokens: 50,
     });
     // (100*2.5 + 50*10)/1e6 = 750/1e6 = 0.00075
     expect(h.events[0].request.cost).toBeCloseTo(0.00075);
+    expect(h.events[0].request.isStreaming).toBe(true);
+    expect(h.events[1].span.attributes['llmops.is_streaming']).toBe(true);
 
     // the forwarded request opted into usage
     const init = fetchMock.mock.calls[0][1] as RequestInit;
@@ -172,7 +191,53 @@ describe('gateway telemetry', () => {
     expect((await res.json()).error).toBe('nope');
 
     await h.settle();
-    expect(h.events).toHaveLength(1);
+    expect(h.events).toHaveLength(2);
     expect(h.events[0].request.status).toBe('error');
+    expect(h.events[1].span.status).toBe('error');
+  });
+
+  it('continues incoming W3C trace context and applies trace names', async () => {
+    const h = harness();
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            choices: [{ message: { role: 'assistant', content: 'hey' } }],
+            usage: { prompt_tokens: 1, completion_tokens: 1 },
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        ),
+    );
+    const traceId = '11111111111111111111111111111111';
+    const parentSpanId = '2222222222222222';
+    const req = chatRequest('@openai/gpt-4o');
+    req.headers.set('traceparent', `00-${traceId}-${parentSpanId}-01`);
+    req.headers.set('x-llmops-trace-name', 'checkout-agent');
+    req.headers.set('x-llmops-span-name', 'generate-answer');
+    const gw = createGateway({
+      providers: [{ provider: 'openai', slug: 'openai', apiKey: 'k' }],
+      getProviderMetadata: metadata,
+      telemetry: h.telemetry as never,
+      waitUntil: h.waitUntil,
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+
+    const res = await gw(req);
+    await res.text();
+    await h.settle();
+
+    const spanEvent = h.events[1];
+    expect(spanEvent.span).toMatchObject({
+      traceId,
+      parentSpanId,
+      name: 'generate-answer',
+    });
+    expect(spanEvent.trace).toMatchObject({
+      traceId,
+      name: 'checkout-agent',
+    });
+    expect(res.headers.get('traceparent')).toMatch(
+      new RegExp(`^00-${traceId}-[0-9a-f]{16}-01$`),
+    );
   });
 });

--- a/packages/gateway/src/instrument.ts
+++ b/packages/gateway/src/instrument.ts
@@ -1,9 +1,15 @@
 import type {
   LLMRequestRecord,
   ModelPricing,
+  SpanRecord,
   TelemetrySink,
   TokenUsage,
+  TraceRecord,
 } from '@llmops/core';
+import {
+  applyTraceHeaders,
+  type GatewayTraceContext,
+} from './trace-context';
 
 export interface InstrumentContext {
   telemetry: TelemetrySink;
@@ -13,11 +19,13 @@ export interface InstrumentContext {
   ) => Promise<ModelPricing | null>;
   waitUntil?: (promise: Promise<unknown>) => void;
   requestId: string;
+  trace: GatewayTraceContext;
   provider: string;
   model: string;
   input: unknown;
   startedAt: string;
   startMs: number;
+  isStreaming: boolean;
 }
 
 /**
@@ -35,7 +43,7 @@ export function instrumentResponse(
       ctx,
       emit(ctx, undefined, undefined, 'error', `upstream ${upstream.status}`),
     );
-    return upstream;
+    return withTraceHeaders(upstream, ctx);
   }
 
   const contentType = upstream.headers.get('content-type') ?? '';
@@ -44,21 +52,31 @@ export function instrumentResponse(
   if (contentType.includes('text/event-stream') && upstream.body) {
     const [toCaller, toMeter] = upstream.body.tee();
     schedule(ctx, meterStream(ctx, toMeter));
-    return new Response(toCaller, {
+    return withTraceHeaders(new Response(toCaller, {
       status: upstream.status,
       statusText: upstream.statusText,
       headers: upstream.headers,
-    });
+    }), ctx);
   }
 
   // Non-streaming JSON: parse usage off a clone.
   if (contentType.includes('application/json')) {
     schedule(ctx, meterJson(ctx, upstream.clone()));
-    return upstream;
+    return withTraceHeaders(upstream, ctx);
   }
 
   // Multipart / binary (audio, images) — not instrumentable; pass through.
-  return upstream;
+  return withTraceHeaders(upstream, ctx);
+}
+
+function withTraceHeaders(response: Response, ctx: InstrumentContext): Response {
+  const headers = new Headers(response.headers);
+  applyTraceHeaders(headers, ctx.requestId, ctx.trace);
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
 }
 
 function schedule(ctx: InstrumentContext, work: Promise<unknown>): void {
@@ -96,6 +114,9 @@ async function emit(
   status: 'success' | 'error',
   error?: string,
 ): Promise<void> {
+  const endedAt = new Date().toISOString();
+  const latencyMs = Date.now() - ctx.startMs;
+  const cost = usage ? await computeCostDollars(ctx, usage) : undefined;
   const request: LLMRequestRecord = {
     requestId: ctx.requestId,
     provider: ctx.provider,
@@ -103,13 +124,50 @@ async function emit(
     input: ctx.input,
     output: output ?? null,
     usage,
-    cost: usage ? await computeCostDollars(ctx, usage) : undefined,
-    latencyMs: Date.now() - ctx.startMs,
+    cost,
+    latencyMs,
+    isStreaming: ctx.isStreaming,
+    traceId: ctx.trace.traceId,
+    spanId: ctx.trace.spanId,
     status,
     error,
     startedAt: ctx.startedAt,
   };
-  ctx.telemetry.emit([{ type: 'llm_request', request }]);
+  const span: SpanRecord = {
+    traceId: ctx.trace.traceId,
+    spanId: ctx.trace.spanId,
+    parentSpanId: ctx.trace.parentSpanId,
+    name: ctx.trace.spanName ?? `${ctx.provider}/${ctx.model}`,
+    kind: 'server',
+    input: ctx.input,
+    output: output ?? null,
+    usage,
+    cost,
+    status: status === 'success' ? 'ok' : 'error',
+    error,
+    attributes: {
+      'gen_ai.operation.name': 'chat',
+      'gen_ai.provider.name': ctx.provider,
+      'gen_ai.request.model': ctx.model,
+      'llmops.request.id': ctx.requestId,
+      'llmops.is_streaming': ctx.isStreaming,
+    },
+    startedAt: ctx.startedAt,
+    endedAt,
+  };
+  const trace: TraceRecord = {
+    traceId: ctx.trace.traceId,
+    name: ctx.trace.traceName ?? `${ctx.provider}/${ctx.model}`,
+    sessionId: ctx.trace.sessionId,
+    userId: ctx.trace.userId,
+    status: status === 'success' ? 'ok' : 'error',
+    startedAt: ctx.startedAt,
+    endedAt,
+  };
+  ctx.telemetry.emit([
+    { type: 'llm_request', request },
+    { type: 'span', span, trace },
+  ]);
 }
 
 /**

--- a/packages/gateway/src/trace-context.ts
+++ b/packages/gateway/src/trace-context.ts
@@ -1,0 +1,72 @@
+export const TRACE_ID_HEADER = 'x-llmops-trace-id';
+export const SPAN_ID_HEADER = 'x-llmops-span-id';
+export const TRACE_NAME_HEADER = 'x-llmops-trace-name';
+export const SPAN_NAME_HEADER = 'x-llmops-span-name';
+export const SESSION_ID_HEADER = 'x-llmops-session-id';
+export const USER_ID_HEADER = 'x-llmops-user-id';
+export const REQUEST_ID_HEADER = 'x-llmops-request-id';
+
+export interface GatewayTraceContext {
+  traceId: string;
+  spanId: string;
+  parentSpanId?: string;
+  traceName?: string;
+  spanName?: string;
+  sessionId?: string;
+  userId?: string;
+}
+
+function randomHex(bytes: number): string {
+  const value = new Uint8Array(bytes);
+  crypto.getRandomValues(value);
+  return Array.from(value, (byte) => byte.toString(16).padStart(2, '0')).join('');
+}
+
+function parseTraceparent(
+  value: string | null,
+): { traceId: string; parentSpanId: string } | null {
+  if (!value) return null;
+  const match =
+    /^00-([0-9a-f]{32})-([0-9a-f]{16})-[0-9a-f]{2}(?:-.*)?$/i.exec(
+      value.trim(),
+    );
+  if (!match || !match[1] || !match[2]) return null;
+  if (/^0+$/.test(match[1]) || /^0+$/.test(match[2])) return null;
+  return {
+    traceId: match[1].toLowerCase(),
+    parentSpanId: match[2].toLowerCase(),
+  };
+}
+
+function validTraceId(value: string | null): string | undefined {
+  return value && /^[0-9a-f]{32}$/i.test(value) && !/^0+$/.test(value)
+    ? value.toLowerCase()
+    : undefined;
+}
+
+export function resolveGatewayTraceContext(
+  headers: Headers,
+): GatewayTraceContext {
+  const parent = parseTraceparent(headers.get('traceparent'));
+  return {
+    traceId:
+      parent?.traceId ?? validTraceId(headers.get(TRACE_ID_HEADER)) ?? randomHex(16),
+    spanId: randomHex(8),
+    parentSpanId: parent?.parentSpanId,
+    traceName: headers.get(TRACE_NAME_HEADER) ?? undefined,
+    spanName: headers.get(SPAN_NAME_HEADER) ?? undefined,
+    sessionId: headers.get(SESSION_ID_HEADER) ?? undefined,
+    userId: headers.get(USER_ID_HEADER) ?? undefined,
+  };
+}
+
+export function applyTraceHeaders(
+  headers: Headers,
+  requestId: string,
+  trace: GatewayTraceContext,
+): void {
+  headers.set(REQUEST_ID_HEADER, requestId);
+  headers.set(TRACE_ID_HEADER, trace.traceId);
+  headers.set(SPAN_ID_HEADER, trace.spanId);
+  headers.set('traceparent', `00-${trace.traceId}-${trace.spanId}-01`);
+}

--- a/packages/sdk/src/telemetry/store-sink.test.ts
+++ b/packages/sdk/src/telemetry/store-sink.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { TelemetryStore } from './interface';
+import { createStoreSink } from './store-sink';
+import type { LLMRequestInsert, SpanInsert, TraceUpsert } from './types';
+
+describe('createStoreSink', () => {
+  it('preserves the streaming flag on LLM request records', async () => {
+    const batchInsertRequests = vi.fn(
+      async (_requests: LLMRequestInsert[]) => ({ count: 1 }),
+    );
+    const store = {
+      batchInsertRequests,
+      batchInsertSpans: vi.fn(async () => ({ count: 0 })),
+      upsertTrace: vi.fn(async () => null),
+    } as unknown as TelemetryStore;
+    const sink = createStoreSink(store);
+
+    sink.emit([
+      {
+        type: 'llm_request',
+        request: {
+          requestId: crypto.randomUUID(),
+          provider: 'openai',
+          model: 'gpt-4o-mini',
+          input: {},
+          output: null,
+          isStreaming: true,
+          status: 'success',
+          startedAt: new Date().toISOString(),
+        },
+      },
+    ]);
+    await sink.flush();
+
+    expect(batchInsertRequests).toHaveBeenCalledOnce();
+    expect(batchInsertRequests.mock.calls[0]?.[0][0]?.isStreaming).toBe(true);
+  });
+
+  it('persists linked span and trace events', async () => {
+    const batchInsertSpans = vi.fn(async (_spans: SpanInsert[]) => ({
+      count: 1,
+    }));
+    const upsertTrace = vi.fn(async (_trace: TraceUpsert) => undefined);
+    const store = {
+      batchInsertRequests: vi.fn(async () => ({ count: 0 })),
+      batchInsertSpans,
+      upsertTrace,
+    } as unknown as TelemetryStore;
+    const sink = createStoreSink(store);
+    const traceId = '1'.repeat(32);
+    const spanId = '2'.repeat(16);
+    const startedAt = new Date().toISOString();
+
+    sink.emit([
+      {
+        type: 'span',
+        span: {
+          traceId,
+          spanId,
+          name: 'openai/gpt-4o-mini',
+          kind: 'server',
+          usage: { inputTokens: 12, outputTokens: 3 },
+          cost: 0.000009,
+          status: 'ok',
+          startedAt,
+          endedAt: startedAt,
+        },
+        trace: {
+          traceId,
+          name: 'e2e-trace',
+          status: 'ok',
+          startedAt,
+          endedAt: startedAt,
+        },
+      },
+    ]);
+    await sink.flush();
+
+    expect(batchInsertSpans.mock.calls[0]?.[0][0]).toMatchObject({
+      traceId,
+      spanId,
+      name: 'openai/gpt-4o-mini',
+      status: 1,
+    });
+    expect(upsertTrace.mock.calls[0]?.[0]).toMatchObject({
+      traceId,
+      name: 'e2e-trace',
+      status: 'ok',
+      spanCount: 1,
+      totalInputTokens: 12,
+      totalOutputTokens: 3,
+      totalTokens: 15,
+      totalCost: 9,
+    });
+  });
+});

--- a/packages/sdk/src/telemetry/store-sink.ts
+++ b/packages/sdk/src/telemetry/store-sink.ts
@@ -1,13 +1,13 @@
 import type {
-  TelemetrySink,
-  TelemetryEvent,
   LLMRequestRecord,
   SpanRecord,
+  TelemetryEvent,
+  TelemetrySink,
   TraceRecord,
 } from '@llmops/core';
 import { dollarsToMicroDollars, logger } from '@llmops/core';
-import type { LLMRequestInsert, SpanInsert, TraceUpsert } from './types';
 import type { TelemetryStore } from './interface';
+import type { LLMRequestInsert, SpanInsert, TraceUpsert } from './types';
 
 export interface StoreSinkConfig {
   flushIntervalMs?: number;
@@ -57,7 +57,7 @@ export function createStoreSink(
       } else {
         spans.push(convertSpan(event.span));
         if (event.trace) {
-          traces.push(convertTrace(event.trace));
+          traces.push(convertTrace(event.trace, event.span));
         }
       }
     }
@@ -119,7 +119,7 @@ function convertRequest(r: LLMRequestRecord): LLMRequestInsert {
     endpoint: '/chat/completions',
     statusCode: r.status === 'error' ? 500 : 200,
     latencyMs: r.latencyMs ?? 0,
-    isStreaming: false,
+    isStreaming: r.isStreaming ?? false,
     tags: r.tags ?? {},
     traceId: r.traceId ?? null,
     spanId: r.spanId ?? null,
@@ -159,8 +159,7 @@ function convertSpan(span: SpanRecord): SpanInsert {
     startTime,
     endTime,
     durationMs,
-    provider:
-      (span.attributes?.['gen_ai.provider.name'] as string) ?? null,
+    provider: (span.attributes?.['gen_ai.provider.name'] as string) ?? null,
     model: (span.attributes?.['gen_ai.request.model'] as string) ?? null,
     promptTokens,
     completionTokens,
@@ -173,11 +172,13 @@ function convertSpan(span: SpanRecord): SpanInsert {
   };
 }
 
-function convertTrace(trace: TraceRecord): TraceUpsert {
+function convertTrace(trace: TraceRecord, span?: SpanRecord): TraceUpsert {
   const startTime = new Date(trace.startedAt);
   const endTime = trace.endedAt ? new Date(trace.endedAt) : null;
   const durationMs =
     endTime != null ? endTime.getTime() - startTime.getTime() : null;
+  const totalInputTokens = span?.usage?.inputTokens ?? 0;
+  const totalOutputTokens = span?.usage?.outputTokens ?? 0;
 
   return {
     traceId: trace.traceId,
@@ -188,11 +189,11 @@ function convertTrace(trace: TraceRecord): TraceUpsert {
     startTime,
     endTime,
     durationMs,
-    spanCount: 1,
-    totalInputTokens: 0,
-    totalOutputTokens: 0,
-    totalTokens: 0,
-    totalCost: 0,
+    spanCount: span ? 1 : 0,
+    totalInputTokens,
+    totalOutputTokens,
+    totalTokens: totalInputTokens + totalOutputTokens,
+    totalCost: span?.cost != null ? dollarsToMicroDollars(span.cost) : 0,
     tags: {},
     metadata: trace.metadata ?? {},
   };


### PR DESCRIPTION
## Summary

- generate or continue W3C trace context for every metered gateway call
- return request, trace, span, and `traceparent` response headers
- emit linked `llm_request`, span, and trace telemetry for streaming and non-streaming responses
- preserve custom trace/span names, session IDs, user IDs, and parent-span linkage
- persist trace-level token/cost rollups and the correct `isStreaming` request flag
- add gateway emission and SDK persistence regression tests

## Test plan

- [x] `pnpm --filter @llmops/core run typecheck`
- [x] `pnpm --filter @llmops/gateway run typecheck`
- [x] `pnpm --filter @llmops/gateway run test -- --run` — 12/12
- [x] `pnpm --filter @llmops/sdk run typecheck`
- [x] `pnpm --filter @llmops/sdk run test -- --run` — 3/3
- [x] `pnpm --filter @llmops/app run test -- --run` — 12/12
- [x] Live OpenAI E2E: non-streaming request persisted linked request/span/trace
- [x] Live OpenAI E2E: streaming request persisted linked request/span/trace
- [x] Dashboard trace list/detail APIs return usage, cost, status, names, and linkage
- [x] Gateway runtime bundle contains 0 `@llmops/core` references

App typecheck remains limited to the three known `src/server/lib/zv.ts` portability errors.
