### PR TITLE
fix(evals): repair runner and telemetry datasets

### DIFF
--- a/examples/eval/README.md
+++ b/examples/eval/README.md
@@ -17,7 +17,7 @@ pnpm eval
 ## Run a specific eval
 
 ```bash
-npx @llmops/cli eval evals/support-bot.eval.ts
+npx @llmops/cli eval -t evals/support-bot.eval.ts
 ```
 
 ## JSON output (for CI)
@@ -25,6 +25,47 @@ npx @llmops/cli eval evals/support-bot.eval.ts
 ```bash
 pnpm eval:json
 ```
+
+The command writes only valid JSON to stdout in this mode, so it can be piped
+directly to tools such as `jq`.
+
+## Evaluate production traffic
+
+Every telemetry store can turn persisted requests into the same dataset shape
+accepted by `evaluate()`:
+
+```ts
+import { evaluate } from '@llmops/sdk/eval';
+import { pgStore } from '@llmops/sdk/store/pg';
+
+const store = pgStore(process.env.POSTGRES_URL!);
+const data = store.dataset({
+  provider: 'openai',
+  since: '7d',
+  limit: 100,
+  map: (request) => ({
+    data: request.input,
+    target: request.output,
+    metadata: {
+      requestId: request.requestId,
+      model: request.model,
+      cost: request.cost,
+    },
+  }),
+});
+
+await evaluate({
+  name: 'production-regression',
+  data,
+  executor: async (input) => runCandidate(input),
+  evaluators: {
+    // Add deterministic or judge-based scorers here.
+  },
+});
+```
+
+Relative `since` values support minutes, hours, days, and weeks (`30m`, `24h`,
+`7d`, `2w`). An absolute ISO timestamp also works.
 
 ## Results
 

--- a/packages/cli/src/commands/eval.ts
+++ b/packages/cli/src/commands/eval.ts
@@ -1,7 +1,18 @@
-import { command, string, boolean as booleanOption } from '@drizzle-team/brocli';
-import { existsSync, readdirSync, readFileSync, statSync, writeFileSync, mkdirSync, rmSync } from 'node:fs';
-import { resolve, join, basename } from 'node:path';
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+} from 'node:fs';
+import { basename, join, resolve } from 'node:path';
+import {
+  boolean as booleanOption,
+  command,
+  string,
+} from '@drizzle-team/brocli';
 import chalk from 'chalk';
 
 /**
@@ -35,7 +46,11 @@ function collectEvalFiles(dir: string): string[] {
 
   for (const entry of entries) {
     const fullPath = join(dir, entry.name);
-    if (entry.isDirectory() && !entry.name.startsWith('.') && entry.name !== 'node_modules') {
+    if (
+      entry.isDirectory() &&
+      !entry.name.startsWith('.') &&
+      entry.name !== 'node_modules'
+    ) {
       files.push(...collectEvalFiles(fullPath));
     } else if (
       entry.isFile() &&
@@ -55,12 +70,16 @@ function collectEvalFiles(dir: string): string[] {
 async function bundleAndRun(
   file: string,
   env: Record<string, string | undefined>,
-): Promise<void> {
+  jsonOutput: boolean,
+): Promise<string | undefined> {
   const esbuild = await import('esbuild');
 
   const tmpDir = join(process.cwd(), '.llmops-eval-tmp');
   mkdirSync(tmpDir, { recursive: true });
-  const outFile = join(tmpDir, `${basename(file, '.ts').replace('.eval', '')}_eval.mjs`);
+  const outFile = join(
+    tmpDir,
+    `${basename(file, '.ts').replace('.eval', '')}_eval.mjs`,
+  );
 
   try {
     await esbuild.build({
@@ -88,11 +107,21 @@ async function bundleAndRun(
       },
     });
 
-    execSync(`node ${outFile}`, {
+    if (jsonOutput) {
+      return execFileSync(process.execPath, [outFile], {
+        stdio: ['ignore', 'pipe', 'inherit'],
+        encoding: 'utf8',
+        env: env as Record<string, string>,
+        cwd: process.cwd(),
+      });
+    }
+
+    execFileSync(process.execPath, [outFile], {
       stdio: 'inherit',
       env: env as Record<string, string>,
       cwd: process.cwd(),
     });
+    return undefined;
   } finally {
     // Clean up temp files
     try {
@@ -115,12 +144,11 @@ export const evalCommand = command({
       .default('./llmops-evals')
       .desc('Output directory for results')
       .alias('o'),
-    json: booleanOption()
-      .desc('Output results as JSON to stdout')
-      .alias('j'),
+    json: booleanOption().desc('Output results as JSON to stdout').alias('j'),
   },
   handler: async (opts) => {
     const target = opts.target;
+    const jsonOutput = opts.json === true;
     const files = findEvalFiles(target);
 
     if (files.length === 0) {
@@ -132,24 +160,34 @@ export const evalCommand = command({
       process.exit(1);
     }
 
-    console.log(
-      chalk.dim(`Found ${files.length} eval file${files.length > 1 ? 's' : ''}`),
-    );
+    if (!jsonOutput) {
+      console.log(
+        chalk.dim(
+          `Found ${files.length} eval file${files.length > 1 ? 's' : ''}`,
+        ),
+      );
+    }
 
     const env: Record<string, string | undefined> = {
       ...process.env,
       LLMOPS_EVAL_OUTPUT_DIR: resolve(opts.outputDir),
-      ...(opts.json ? { LLMOPS_EVAL_OUTPUT: 'json' } : {}),
+      ...(jsonOutput ? { LLMOPS_EVAL_OUTPUT: 'json' } : {}),
     };
 
     let hasErrors = false;
+    const jsonResults: unknown[] = [];
 
     for (const file of files) {
       const name = basename(file);
-      console.log(chalk.dim(`\nRunning ${name}...`));
+      if (!jsonOutput) {
+        console.log(chalk.dim(`\nRunning ${name}...`));
+      }
 
       try {
-        await bundleAndRun(file, env);
+        const output = await bundleAndRun(file, env, jsonOutput);
+        if (jsonOutput && output) {
+          jsonResults.push(JSON.parse(output));
+        }
       } catch (err) {
         hasErrors = true;
         console.error(chalk.red(`\n✗ ${name} failed`));
@@ -159,9 +197,14 @@ export const evalCommand = command({
       }
     }
 
+    if (jsonOutput) {
+      const output = jsonResults.length === 1 ? jsonResults[0] : jsonResults;
+      process.stdout.write(`${JSON.stringify(output, null, 2)}\n`);
+    }
+
     // Print summary
     const outputDir = resolve(opts.outputDir);
-    if (existsSync(outputDir) && !opts.json) {
+    if (existsSync(outputDir) && !jsonOutput) {
       const evalDirs = readdirSync(outputDir, { withFileTypes: true })
         .filter((d) => d.isDirectory())
         .map((d) => d.name);
@@ -187,7 +230,9 @@ export const evalCommand = command({
                 .join('  ');
               console.log(`  ${chalk.white(evalDir)}  ${chalk.cyan(scoreStr)}`);
             } catch {
-              console.log(`  ${chalk.white(evalDir)}  ${chalk.dim(resultFiles[0])}`);
+              console.log(
+                `  ${chalk.white(evalDir)}  ${chalk.dim(resultFiles[0])}`,
+              );
             }
           }
         }

--- a/packages/sdk/src/eval/evaluate.test.ts
+++ b/packages/sdk/src/eval/evaluate.test.ts
@@ -1,0 +1,105 @@
+import { mkdtempSync, readdirSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { evaluate } from './evaluate';
+
+const tempDirs: string[] = [];
+
+function outputDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'llmops-eval-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('evaluate', () => {
+  it('keeps duplicate datapoints in their original positions', async () => {
+    const datapoint = { data: { value: 2 }, target: 4 };
+    const result = await evaluate({
+      name: 'duplicates',
+      data: [datapoint, datapoint],
+      executor: async ({ value }) => value * 2,
+      evaluators: {
+        exact: (output, target) => (output === target ? 1 : 0),
+      },
+      outputDir: outputDir(),
+    });
+
+    expect('results' in result && result.results).toHaveLength(2);
+    expect(
+      'results' in result && result.results.map((row) => row.output),
+    ).toEqual([4, 4]);
+  });
+
+  it('scores null as a valid executor output', async () => {
+    const result = await evaluate({
+      name: 'null-output',
+      data: [{ data: 'input' }],
+      executor: async () => null,
+      evaluators: {
+        isNull: (output) => (output === null ? 1 : 0),
+      },
+      outputDir: outputDir(),
+    });
+
+    expect('scores' in result && result.scores.isNull.mean).toBe(1);
+  });
+
+  it('rejects invalid concurrency instead of hanging', async () => {
+    await expect(
+      evaluate({
+        name: 'invalid-concurrency',
+        data: [{ data: 'input' }],
+        executor: async (data) => data,
+        evaluators: {},
+        concurrency: 0,
+        outputDir: outputDir(),
+      }),
+    ).rejects.toThrow('concurrency must be a positive integer');
+  });
+
+  it('writes a complete JSON result for CI consumption', async () => {
+    const dir = outputDir();
+    const result = await evaluate({
+      name: 'persisted',
+      data: [{ data: 2, target: 4 }],
+      executor: async (value) => value * 2,
+      evaluators: {
+        exact: (output, target) => (output === target ? 1 : 0),
+      },
+      outputDir: dir,
+    });
+
+    const [file] = readdirSync(join(dir, 'persisted'));
+    const stored = JSON.parse(
+      readFileSync(join(dir, 'persisted', file), 'utf8'),
+    );
+    expect(stored.runId).toBe(result.runId);
+    expect(stored.scores.exact.mean).toBe(1);
+  });
+
+  it('counts evaluator failures instead of reporting a false pass', async () => {
+    const result = await evaluate({
+      name: 'evaluator-error',
+      data: [{ data: 'input' }],
+      executor: async (data) => data,
+      evaluators: {
+        broken: () => {
+          throw new Error('judge unavailable');
+        },
+      },
+      outputDir: outputDir(),
+    });
+
+    expect('errors' in result && result.errors).toBe(1);
+    expect('results' in result && result.results[0].error).toContain(
+      'evaluator "broken": judge unavailable',
+    );
+  });
+});

--- a/packages/sdk/src/eval/evaluate.ts
+++ b/packages/sdk/src/eval/evaluate.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'node:crypto';
-import { writeFileSync, mkdirSync } from 'node:fs';
+import { mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { InlineDataset, type EvaluationDataset } from './dataset';
+import { type EvaluationDataset, InlineDataset } from './dataset';
 import type {
   DatapointResult,
   EvaluateOptions,
@@ -27,11 +27,11 @@ const YELLOW = '\x1b[33m';
 async function pool<T>(
   items: T[],
   concurrency: number,
-  fn: (item: T) => Promise<void>,
+  fn: (item: T, index: number) => Promise<void>,
 ) {
   const executing: Promise<void>[] = [];
-  for (const item of items) {
-    const p = fn(item).then(() => {
+  for (const [index, item] of items.entries()) {
+    const p = fn(item, index).then(() => {
       executing.splice(executing.indexOf(p), 1);
     });
     executing.push(p);
@@ -51,9 +51,7 @@ function computeStats(values: number[]): ScoreStats {
   const sum = sorted.reduce((a, b) => a + b, 0);
   const mid = Math.floor(sorted.length / 2);
   const median =
-    sorted.length % 2 === 0
-      ? (sorted[mid - 1] + sorted[mid]) / 2
-      : sorted[mid];
+    sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
 
   return {
     mean: sum / sorted.length,
@@ -76,19 +74,18 @@ function printHeader(name: string, total: number) {
   w.write(`  ${DIM}${'─'.repeat(50)}${RESET}\n`);
 }
 
-function printDatapointResult(
-  idx: number,
-  total: number,
-  dp: DatapointResult,
-) {
+function printDatapointResult(idx: number, total: number, dp: DatapointResult) {
   if (isSilent) return;
 
-  const label = typeof dp.data === 'object' && dp.data !== null
-    ? JSON.stringify(dp.data).slice(0, 50)
-    : String(dp.data).slice(0, 50);
+  const label =
+    typeof dp.data === 'object' && dp.data !== null
+      ? JSON.stringify(dp.data).slice(0, 50)
+      : String(dp.data).slice(0, 50);
 
   if (dp.error) {
-    w.write(`  ${RED}✗${RESET} ${DIM}[${idx + 1}/${total}]${RESET} ${label}  ${RED}ERROR${RESET} ${DIM}${dp.error.slice(0, 60)}${RESET}\n`);
+    w.write(
+      `  ${RED}✗${RESET} ${DIM}[${idx + 1}/${total}]${RESET} ${label}  ${RED}ERROR${RESET} ${DIM}${dp.error.slice(0, 60)}${RESET}\n`,
+    );
     return;
   }
 
@@ -100,7 +97,9 @@ function printDatapointResult(
     })
     .join('  ');
 
-  w.write(`  ${GREEN}✓${RESET} ${DIM}[${idx + 1}/${total}]${RESET} ${label}  ${scoreStr}  ${DIM}${dp.durationMs}ms${RESET}\n`);
+  w.write(
+    `  ${GREEN}✓${RESET} ${DIM}[${idx + 1}/${total}]${RESET} ${label}  ${scoreStr}  ${DIM}${dp.durationMs}ms${RESET}\n`,
+  );
 }
 
 function scoreBar(score: number, width = 20): string {
@@ -124,7 +123,9 @@ function printSummary(result: EvaluateResult) {
   if (entries.length > 0) {
     const maxNameLen = Math.max(...entries.map(([n]) => n.length), 10);
 
-    w.write(`  ${DIM}${'Evaluator'.padEnd(maxNameLen)}  ${'Mean'.padStart(6)}  ${'Bar'.padEnd(20)}  ${'Min'.padStart(5)}  ${'Max'.padStart(5)}  ${'Med'.padStart(5)}${RESET}\n`);
+    w.write(
+      `  ${DIM}${'Evaluator'.padEnd(maxNameLen)}  ${'Mean'.padStart(6)}  ${'Bar'.padEnd(20)}  ${'Min'.padStart(5)}  ${'Max'.padStart(5)}  ${'Med'.padStart(5)}${RESET}\n`,
+    );
     w.write(`  ${DIM}${'─'.repeat(maxNameLen + 50)}${RESET}\n`);
 
     for (const [name, stats] of entries) {
@@ -172,23 +173,25 @@ async function runSingleExecutor<D, T, O>(
 
   printHeader(name, datapoints.length);
 
-  await pool(datapoints, concurrency, async (dp) => {
-    const idx = datapoints.indexOf(dp);
+  await pool(datapoints, concurrency, async (dp, idx) => {
     const dpStart = Date.now();
-    let output: O | null = null;
+    let output: O | undefined;
     let error: string | undefined;
+    let executed = false;
+    const evaluatorErrors: string[] = [];
     const scores: Record<string, number> = {};
 
     try {
       output = await executor(dp.data);
+      executed = true;
     } catch (err) {
       error = err instanceof Error ? err.message : String(err);
     }
 
-    if (!error && output !== null) {
+    if (!error && executed) {
       for (const [evalName, evaluator] of Object.entries(evaluators)) {
         try {
-          const result = await evaluator(output, dp.target, dp.data);
+          const result = await evaluator(output as O, dp.target, dp.data);
           if (typeof result === 'number') {
             scores[evalName] = result;
           } else {
@@ -198,12 +201,20 @@ async function runSingleExecutor<D, T, O>(
           }
         } catch (evalErr) {
           scores[evalName] = NaN;
-          const msg = evalErr instanceof Error ? evalErr.message : String(evalErr);
+          const msg =
+            evalErr instanceof Error ? evalErr.message : String(evalErr);
+          evaluatorErrors.push(`evaluator "${evalName}": ${msg}`);
           if (!isSilent) {
-            w.write(`  ${YELLOW}⚠${RESET} ${DIM}evaluator "${evalName}":${RESET} ${msg.slice(0, 80)}\n`);
+            w.write(
+              `  ${YELLOW}⚠${RESET} ${DIM}evaluator "${evalName}":${RESET} ${msg.slice(0, 80)}\n`,
+            );
           }
         }
       }
+    }
+
+    if (!error && evaluatorErrors.length > 0) {
+      error = evaluatorErrors.join('; ');
     }
 
     const dpResult: DatapointResult<D, O> = {
@@ -246,15 +257,17 @@ export async function evaluate<
 
   const runId = randomUUID();
 
+  if (!Number.isInteger(concurrency) || concurrency < 1) {
+    throw new Error('evaluate(): concurrency must be a positive integer');
+  }
+
   if (executor && variants) {
     throw new Error(
       'evaluate(): provide either executor or variants, not both',
     );
   }
   if (!executor && !variants) {
-    throw new Error(
-      'evaluate(): provide either executor or variants',
-    );
+    throw new Error('evaluate(): provide either executor or variants');
   }
 
   const dataset = Array.isArray(data) ? new InlineDataset(data) : data;

--- a/packages/sdk/src/eval/judge.test.ts
+++ b/packages/sdk/src/eval/judge.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { LLMOpsClient } from '../client';
+import { judgeScorer } from './judge';
+
+function client(fetch: typeof globalThis.fetch): LLMOpsClient {
+  return {
+    provider: () => ({
+      apiKey: 'llmops',
+      baseURL: 'http://llmops.test/api/genai/v1',
+      fetch,
+    }),
+  } as LLMOpsClient;
+}
+
+describe('judgeScorer', () => {
+  it('routes the judge through the gateway and interpolates inputs', async () => {
+    const fetchMock = vi.fn(
+      async (_input: RequestInfo | URL, init?: RequestInit) => {
+        const body = JSON.parse(String(init?.body));
+        expect(body.model).toBe('@openai/gpt-4o-mini');
+        expect(body.messages[1].content).toContain('Expected: Paris');
+        expect(body.messages[1].content).toContain('Actual: Paris');
+        return Response.json({
+          choices: [{ message: { content: '{"score":0.9}' } }],
+        });
+      },
+    );
+    const scorer = judgeScorer({
+      model: '@openai/gpt-4o-mini',
+      prompt: 'Expected: {{target.answer}} Actual: {{output}}',
+      client: client(fetchMock as typeof globalThis.fetch),
+    });
+
+    await expect(
+      scorer('Paris', { answer: 'Paris' }, { question: 'Capital?' }),
+    ).resolves.toBe(0.9);
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it('retries parse failures and clamps the returned score', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        Response.json({ choices: [{ message: { content: 'not json' } }] }),
+      )
+      .mockResolvedValueOnce(
+        Response.json({ choices: [{ message: { content: '{"score":2}' } }] }),
+      );
+    const scorer = judgeScorer({
+      model: '@openai/gpt-4o-mini',
+      prompt: '{{output}}',
+      client: client(fetchMock as typeof globalThis.fetch),
+      maxRetries: 1,
+    });
+
+    await expect(scorer('answer')).resolves.toBe(1);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not retry upstream HTTP failures', async () => {
+    const fetchMock = vi.fn(async () => new Response('quota', { status: 429 }));
+    const scorer = judgeScorer({
+      model: '@openai/gpt-4o-mini',
+      prompt: '{{output}}',
+      client: client(fetchMock as typeof globalThis.fetch),
+      maxRetries: 2,
+    });
+
+    await expect(scorer('answer')).rejects.toThrow(
+      'Judge LLM call failed (429)',
+    );
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/sdk/src/eval/judge.ts
+++ b/packages/sdk/src/eval/judge.ts
@@ -2,42 +2,22 @@ import type { Evaluator, JudgeScorerOptions } from './types';
 
 // ─── Template interpolation ─────────────────────────────────────────────────
 
-function interpolate(
-  template: string,
-  vars: Record<string, unknown>,
-): string {
-  return template.replace(
-    /\{\{(\w+(?:\.\w+)*)\}\}/g,
-    (_, path: string) => {
-      const value = path
-        .split('.')
-        .reduce((obj: any, key: string) => obj?.[key], vars);
-      if (value === undefined || value === null) return '';
-      return typeof value === 'string' ? value : JSON.stringify(value, null, 2);
-    },
-  );
+function interpolate(template: string, vars: Record<string, unknown>): string {
+  return template.replace(/\{\{(\w+(?:\.\w+)*)\}\}/g, (_, path: string) => {
+    const value = path
+      .split('.')
+      .reduce((obj: any, key: string) => obj?.[key], vars);
+    if (value === undefined || value === null) return '';
+    return typeof value === 'string' ? value : JSON.stringify(value, null, 2);
+  });
 }
 
-function buildVars(output: unknown, target?: unknown, data?: unknown): Record<string, unknown> {
-  const vars: Record<string, unknown> = {
-    output: typeof output === 'string' ? output : JSON.stringify(output, null, 2),
-    target: typeof target === 'string' ? target : JSON.stringify(target, null, 2),
-    data: typeof data === 'string' ? data : JSON.stringify(data, null, 2),
-  };
-
-  if (target && typeof target === 'object') {
-    for (const [k, v] of Object.entries(target)) {
-      vars[`target.${k}`] = v;
-    }
-  }
-
-  if (data && typeof data === 'object') {
-    for (const [k, v] of Object.entries(data)) {
-      vars[`data.${k}`] = v;
-    }
-  }
-
-  return vars;
+function buildVars(
+  output: unknown,
+  target?: unknown,
+  data?: unknown,
+): Record<string, unknown> {
+  return { output, target, data };
 }
 
 // ─── Default system message ─────────────────────────────────────────────────
@@ -58,7 +38,10 @@ Example response:
 
 function defaultParse(response: string): number | Record<string, number> {
   // Strip markdown code fences if present
-  let cleaned = response.replace(/```(?:json)?\n?/g, '').replace(/```$/g, '').trim();
+  let cleaned = response
+    .replace(/```(?:json)?\n?/g, '')
+    .replace(/```$/g, '')
+    .trim();
 
   // Try to extract JSON from the response (handle LLMs that add text around it)
   const jsonMatch = cleaned.match(/\{[\s\S]*\}/);
@@ -127,7 +110,9 @@ async function callLLM(
 
   if (!response.ok) {
     const errorBody = await response.text().catch(() => 'unknown error');
-    throw new Error(`Judge LLM call failed (${response.status}): ${errorBody.slice(0, 300)}`);
+    throw new Error(
+      `Judge LLM call failed (${response.status}): ${errorBody.slice(0, 300)}`,
+    );
   }
 
   const body = (await response.json()) as {
@@ -192,7 +177,13 @@ export function judgeScorer(options: JudgeScorerOptions): Evaluator {
 
     for (let attempt = 0; attempt < attempts; attempt++) {
       try {
-        const content = await callLLM(client, model, system, userMessage, temperature);
+        const content = await callLLM(
+          client,
+          model,
+          system,
+          userMessage,
+          temperature,
+        );
         return parse(content);
       } catch (err) {
         lastError = err instanceof Error ? err : new Error(String(err));

--- a/packages/sdk/src/store/d1/d1-store.ts
+++ b/packages/sdk/src/store/d1/d1-store.ts
@@ -1,13 +1,14 @@
 import { randomUUID } from 'node:crypto';
-import type { D1Database } from './types';
+import { createTelemetryDataset } from '../../telemetry/dataset';
 import type { TelemetryStore } from '../../telemetry/interface';
 import type {
-  LLMRequestInsert,
-  TraceUpsert,
-  SpanInsert,
-  SpanEventInsert,
   CostSummaryGroupBy,
+  LLMRequestInsert,
+  SpanEventInsert,
+  SpanInsert,
+  TraceUpsert,
 } from '../../telemetry/types';
+import type { D1Database } from './types';
 
 // ─── JSON column parser ─────────────────────────────────────────────────────
 
@@ -576,9 +577,14 @@ export type D1Store = TelemetryStore & {
  * ```
  */
 export function createD1Store(db: D1Database): D1Store {
+  const requests = createD1LLMRequestsStore(db);
+  const traces = createD1TracesStore(db);
+
   return {
-    ...createD1LLMRequestsStore(db),
-    ...createD1TracesStore(db),
+    ...requests,
+    ...traces,
+    dataset: (query) =>
+      createTelemetryDataset({ ...requests, ...traces }, query),
     _db: db,
   };
 }

--- a/packages/sdk/src/store/sqlite/sqlite-store.ts
+++ b/packages/sdk/src/store/sqlite/sqlite-store.ts
@@ -1,13 +1,14 @@
 import { randomUUID } from 'node:crypto';
-import type { SQLiteDatabase } from './types';
+import { createTelemetryDataset } from '../../telemetry/dataset';
 import type { TelemetryStore } from '../../telemetry/interface';
 import type {
-  LLMRequestInsert,
-  TraceUpsert,
-  SpanInsert,
-  SpanEventInsert,
   CostSummaryGroupBy,
+  LLMRequestInsert,
+  SpanEventInsert,
+  SpanInsert,
+  TraceUpsert,
 } from '../../telemetry/types';
+import type { SQLiteDatabase } from './types';
 
 // ─── JSON column parser (shared with D1 store) ─────────────────────────────
 
@@ -566,9 +567,14 @@ export function createSQLiteStore(path: string): SQLiteStore {
   // Enable WAL mode for better concurrent read performance
   db.exec('PRAGMA journal_mode = WAL');
 
+  const requests = createSQLiteLLMRequestsStore(db);
+  const traces = createSQLiteTracesStore(db);
+
   return {
-    ...createSQLiteLLMRequestsStore(db),
-    ...createSQLiteTracesStore(db),
+    ...requests,
+    ...traces,
+    dataset: (query) =>
+      createTelemetryDataset({ ...requests, ...traces }, query),
     _db: db,
   };
 }

--- a/packages/sdk/src/telemetry/dataset.test.ts
+++ b/packages/sdk/src/telemetry/dataset.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createTelemetryDataset } from './dataset';
+
+describe('createTelemetryDataset', () => {
+  it('filters requests and hydrates input/output from the matching span', async () => {
+    const createdAt = new Date('2026-07-31T10:00:00.000Z');
+    const listRequests = vi.fn(async () => ({
+      data: [
+        {
+          requestId: 'request-1',
+          traceId: 'trace-1',
+          spanId: 'span-1',
+          provider: 'openai',
+          model: 'gpt-4o-mini',
+          promptTokens: 12,
+          completionTokens: 4,
+          cachedTokens: 2,
+          cost: 25,
+          latencyMs: 80,
+          endpoint: '/chat/completions',
+          statusCode: 200,
+          tags: { environment: 'production' },
+          createdAt,
+        },
+      ],
+      total: 1,
+      limit: 10,
+      offset: 0,
+    }));
+    const getTraceWithSpans = vi.fn(async () => ({
+      trace: {},
+      events: [],
+      spans: [
+        {
+          requestId: 'request-1',
+          spanId: 'span-1',
+          input: { messages: [{ role: 'user', content: 'hello' }] },
+          output: { content: 'hi' },
+        },
+      ],
+    }));
+    const dataset = createTelemetryDataset(
+      { listRequests, getTraceWithSpans },
+      {
+        provider: 'openai',
+        model: 'gpt-4o-mini',
+        since: '7d',
+        limit: 10,
+        tags: { environment: ['production'] },
+        map: (request) => ({
+          data: request.input as { messages: unknown[] },
+          target: request.output as { content: string },
+          metadata: {
+            requestId: request.requestId,
+            cost: request.cost,
+            inputTokens: request.usage?.inputTokens,
+          },
+        }),
+      },
+    );
+
+    expect(await dataset.size()).toBe(1);
+    expect(await dataset.get(0)).toEqual({
+      data: { messages: [{ role: 'user', content: 'hello' }] },
+      target: { content: 'hi' },
+      metadata: { requestId: 'request-1', cost: 0.000025, inputTokens: 12 },
+    });
+    expect(listRequests).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: 'openai',
+        model: 'gpt-4o-mini',
+        limit: 10,
+        tags: { environment: ['production'] },
+        startDate: expect.any(Date),
+      }),
+    );
+    expect(getTraceWithSpans).toHaveBeenCalledWith('trace-1');
+  });
+
+  it('loads once and reuses a trace shared by multiple requests', async () => {
+    const listRequests = vi.fn(async () => ({
+      data: [
+        {
+          requestId: 'request-1',
+          traceId: 'trace-1',
+          spanId: 'span-1',
+          provider: 'openai',
+          model: 'gpt-4o-mini',
+          createdAt: '2026-07-31T10:00:00.000Z',
+        },
+        {
+          requestId: 'request-2',
+          traceId: 'trace-1',
+          spanId: 'span-2',
+          provider: 'openai',
+          model: 'gpt-4o-mini',
+          createdAt: '2026-07-31T10:00:01.000Z',
+        },
+      ],
+      total: 2,
+      limit: 100,
+      offset: 0,
+    }));
+    const getTraceWithSpans = vi.fn(async () => ({
+      trace: {},
+      events: [],
+      spans: [
+        { requestId: 'request-1', spanId: 'span-1', output: 'one' },
+        { requestId: 'request-2', spanId: 'span-2', output: 'two' },
+      ],
+    }));
+    const dataset = createTelemetryDataset(
+      { listRequests, getTraceWithSpans },
+      { map: (request) => ({ data: request.output }) },
+    );
+
+    expect(await dataset.slice(0, 2)).toEqual([
+      { data: 'one' },
+      { data: 'two' },
+    ]);
+    expect(await dataset.size()).toBe(2);
+    expect(listRequests).toHaveBeenCalledOnce();
+    expect(getTraceWithSpans).toHaveBeenCalledOnce();
+  });
+
+  it('rejects an invalid relative or absolute date', async () => {
+    const dataset = createTelemetryDataset(
+      {
+        listRequests: vi.fn(),
+        getTraceWithSpans: vi.fn(),
+      },
+      { since: 'last-week', map: (request) => ({ data: request.input }) },
+    );
+
+    await expect(dataset.size()).rejects.toThrow('invalid since value');
+  });
+});

--- a/packages/sdk/src/telemetry/dataset.ts
+++ b/packages/sdk/src/telemetry/dataset.ts
@@ -1,0 +1,205 @@
+import type {
+  Datapoint,
+  DatasetQuery,
+  EvaluationDataset,
+  LLMRequestRecord,
+} from '@llmops/core';
+
+interface StoredRequest {
+  requestId: string;
+  traceId?: string | null;
+  spanId?: string | null;
+  provider: string;
+  model: string;
+  promptTokens?: number;
+  completionTokens?: number;
+  cachedTokens?: number;
+  cacheCreationTokens?: number;
+  cost?: number;
+  latencyMs?: number;
+  isStreaming?: boolean;
+  endpoint?: string;
+  statusCode?: number;
+  tags?: Record<string, string> | string;
+  createdAt?: Date | string;
+}
+
+interface StoredSpan {
+  requestId?: string | null;
+  spanId?: string | null;
+  input?: unknown;
+  output?: unknown;
+  statusMessage?: string | null;
+}
+
+export interface DatasetStoreReader {
+  listRequests(params?: {
+    limit?: number;
+    offset?: number;
+    provider?: string;
+    model?: string;
+    startDate?: Date;
+    tags?: Record<string, string[]>;
+  }): Promise<{
+    data: unknown[];
+    total: number;
+    limit: number;
+    offset: number;
+  }>;
+  getTraceWithSpans(
+    traceId: string,
+  ): Promise<
+    { trace: unknown; spans: unknown[]; events: unknown[] } | undefined
+  >;
+}
+
+const DEFAULT_DATASET_LIMIT = 100;
+
+function parseSince(since: string | undefined): Date | undefined {
+  if (!since) return undefined;
+
+  const relative = /^(\d+)(m|h|d|w)$/.exec(since);
+  if (relative) {
+    const amount = Number(relative[1]);
+    const unit = relative[2] as 'm' | 'h' | 'd' | 'w';
+    const unitMs = {
+      m: 60_000,
+      h: 3_600_000,
+      d: 86_400_000,
+      w: 604_800_000,
+    }[unit];
+    return new Date(Date.now() - amount * unitMs);
+  }
+
+  const absolute = new Date(since);
+  if (Number.isNaN(absolute.getTime())) {
+    throw new Error(
+      `dataset(): invalid since value "${since}"; use an ISO date or a relative value such as "7d"`,
+    );
+  }
+  return absolute;
+}
+
+function parseTags(tags: StoredRequest['tags']): Record<string, string> {
+  if (!tags) return {};
+  if (typeof tags !== 'string') return tags;
+  try {
+    return JSON.parse(tags) as Record<string, string>;
+  } catch {
+    return {};
+  }
+}
+
+function toIsoString(value: StoredRequest['createdAt']): string {
+  if (value instanceof Date) return value.toISOString();
+  if (typeof value === 'string') return new Date(value).toISOString();
+  return new Date(0).toISOString();
+}
+
+function findSpan(
+  request: StoredRequest,
+  spans: unknown[],
+): StoredSpan | undefined {
+  return (spans as StoredSpan[]).find(
+    (span) =>
+      span.requestId === request.requestId ||
+      (request.spanId != null && span.spanId === request.spanId),
+  );
+}
+
+function toRequestRecord(
+  request: StoredRequest,
+  span: StoredSpan | undefined,
+): LLMRequestRecord {
+  const statusCode = request.statusCode ?? 200;
+  return {
+    requestId: request.requestId,
+    traceId: request.traceId ?? undefined,
+    spanId: request.spanId ?? undefined,
+    provider: request.provider,
+    model: request.model,
+    input: span?.input ?? null,
+    output: span?.output ?? null,
+    usage: {
+      inputTokens: request.promptTokens ?? 0,
+      outputTokens: request.completionTokens ?? 0,
+      cacheReadTokens: request.cachedTokens ?? 0,
+      cacheWriteTokens: request.cacheCreationTokens ?? 0,
+    },
+    cost: (request.cost ?? 0) / 1_000_000,
+    latencyMs: request.latencyMs ?? 0,
+    isStreaming: request.isStreaming ?? false,
+    endpoint: request.endpoint,
+    statusCode,
+    status: statusCode >= 400 ? 'error' : 'success',
+    error: span?.statusMessage ?? undefined,
+    tags: parseTags(request.tags),
+    startedAt: toIsoString(request.createdAt),
+  };
+}
+
+class TelemetryDataset<D, T> implements EvaluationDataset<D, T> {
+  private loaded?: Promise<Datapoint<D, T>[]>;
+
+  constructor(
+    private readonly store: DatasetStoreReader,
+    private readonly query: DatasetQuery<D, T>,
+  ) {}
+
+  private load(): Promise<Datapoint<D, T>[]> {
+    this.loaded ??= this.loadRows();
+    return this.loaded;
+  }
+
+  private async loadRows(): Promise<Datapoint<D, T>[]> {
+    const page = await this.store.listRequests({
+      provider: this.query.provider,
+      model: this.query.model,
+      startDate: parseSince(this.query.since),
+      limit: this.query.limit ?? DEFAULT_DATASET_LIMIT,
+      offset: 0,
+      tags: this.query.tags,
+    });
+    const requests = page.data as StoredRequest[];
+    const traces = new Map<
+      string,
+      Promise<
+        { trace: unknown; spans: unknown[]; events: unknown[] } | undefined
+      >
+    >();
+
+    return Promise.all(
+      requests.map(async (request) => {
+        let span: StoredSpan | undefined;
+        if (request.traceId) {
+          let trace = traces.get(request.traceId);
+          if (!trace) {
+            trace = this.store.getTraceWithSpans(request.traceId);
+            traces.set(request.traceId, trace);
+          }
+          span = findSpan(request, (await trace)?.spans ?? []);
+        }
+        return this.query.map(toRequestRecord(request, span));
+      }),
+    );
+  }
+
+  async size(): Promise<number> {
+    return (await this.load()).length;
+  }
+
+  async get(index: number): Promise<Datapoint<D, T>> {
+    return (await this.load())[index];
+  }
+
+  async slice(start: number, end: number): Promise<Datapoint<D, T>[]> {
+    return (await this.load()).slice(start, end);
+  }
+}
+
+export function createTelemetryDataset<D, T>(
+  store: DatasetStoreReader,
+  query: DatasetQuery<D, T>,
+): EvaluationDataset<D, T> {
+  return new TelemetryDataset(store, query);
+}

--- a/packages/sdk/src/telemetry/interface.ts
+++ b/packages/sdk/src/telemetry/interface.ts
@@ -1,9 +1,10 @@
+import type { DatasetQuery, EvaluationDataset } from '@llmops/core';
 import type {
-  LLMRequestInsert,
-  TraceUpsert,
-  SpanInsert,
-  SpanEventInsert,
   CostSummaryGroupBy,
+  LLMRequestInsert,
+  SpanEventInsert,
+  SpanInsert,
+  TraceUpsert,
 } from './types';
 
 /**
@@ -11,6 +12,11 @@ import type {
  * Implemented by pgStore, d1Store, and future store backends.
  */
 export interface TelemetryStore {
+  /** Turn stored production requests into an evaluation dataset. */
+  dataset<D = Record<string, unknown>, T = Record<string, unknown>>(
+    query: DatasetQuery<D, T>,
+  ): EvaluationDataset<D, T>;
+
   // ── LLM Requests: writes ──────────────────────────────────────────
   batchInsertRequests(requests: LLMRequestInsert[]): Promise<{ count: number }>;
   insertRequest(request: LLMRequestInsert): Promise<unknown>;
@@ -28,7 +34,12 @@ export interface TelemetryStore {
     startDate?: Date;
     endDate?: Date;
     tags?: Record<string, string[]>;
-  }): Promise<{ data: unknown[]; total: number; limit: number; offset: number }>;
+  }): Promise<{
+    data: unknown[];
+    total: number;
+    limit: number;
+    offset: number;
+  }>;
 
   getRequestByRequestId(requestId: string): Promise<unknown | undefined>;
 
@@ -41,8 +52,14 @@ export interface TelemetryStore {
     tags?: Record<string, string[]>;
   }): Promise<unknown>;
 
-  getCostByModel(params: { startDate: Date; endDate: Date }): Promise<unknown[]>;
-  getCostByProvider(params: { startDate: Date; endDate: Date }): Promise<unknown[]>;
+  getCostByModel(params: {
+    startDate: Date;
+    endDate: Date;
+  }): Promise<unknown[]>;
+  getCostByProvider(params: {
+    startDate: Date;
+    endDate: Date;
+  }): Promise<unknown[]>;
   getDailyCosts(params: { startDate: Date; endDate: Date }): Promise<unknown[]>;
 
   getCostSummary(params: {
@@ -83,9 +100,16 @@ export interface TelemetryStore {
     startDate?: Date;
     endDate?: Date;
     tags?: Record<string, string[]>;
-  }): Promise<{ data: unknown[]; total: number; limit: number; offset: number }>;
+  }): Promise<{
+    data: unknown[];
+    total: number;
+    limit: number;
+    offset: number;
+  }>;
 
-  getTraceWithSpans(traceId: string): Promise<
+  getTraceWithSpans(
+    traceId: string,
+  ): Promise<
     { trace: unknown; spans: unknown[]; events: unknown[] } | undefined
   >;
 

--- a/packages/sdk/src/telemetry/pg-store.ts
+++ b/packages/sdk/src/telemetry/pg-store.ts
@@ -1,26 +1,28 @@
 import { randomUUID } from 'node:crypto';
-import z from 'zod';
 import { logger } from '@llmops/core';
+import z from 'zod';
+import { createTelemetryDataset } from './dataset';
+import type { TelemetryStore } from './interface';
+import type {
+  CostSummaryGroupBy,
+  LLMRequestInsert,
+  SpanEventInsert,
+  SpanInsert,
+  TraceUpsert,
+} from './types';
 import {
   insertLLMRequestSchema,
-  insertSpanSchema,
   insertSpanEventSchema,
+  insertSpanSchema,
   upsertTraceSchema,
-} from './types';
-import type {
-  LLMRequestInsert,
-  TraceUpsert,
-  SpanInsert,
-  SpanEventInsert,
-  CostSummaryGroupBy,
 } from './types';
 
 export type {
-  LLMRequestInsert,
-  TraceUpsert,
-  SpanInsert,
-  SpanEventInsert,
   CostSummaryGroupBy,
+  LLMRequestInsert,
+  SpanEventInsert,
+  SpanInsert,
+  TraceUpsert,
 } from './types';
 export { COST_SUMMARY_GROUP_BY } from './types';
 
@@ -602,8 +604,6 @@ function createTracesStore(pool: any) {
 
 // ─── PgStore ────────────────────────────────────────────────────────────────
 
-import type { TelemetryStore } from './interface';
-
 export type PgStore = TelemetryStore & {
   _pool: unknown;
   _schema: string;
@@ -656,9 +656,14 @@ export function createPgStore(
 
   logger.debug(`pgStore: initialized with schema "${schema}"`);
 
+  const requests = createLLMRequestsStore(pool);
+  const traces = createTracesStore(pool);
+
   return {
-    ...createLLMRequestsStore(pool),
-    ...createTracesStore(pool),
+    ...requests,
+    ...traces,
+    dataset: (query) =>
+      createTelemetryDataset({ ...requests, ...traces }, query),
     _pool: pool,
     _schema: schema,
   };

--- a/packages/sdk/src/telemetry/store-sink.test.ts
+++ b/packages/sdk/src/telemetry/store-sink.test.ts
@@ -1,9 +1,44 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { TelemetryStore } from './interface';
 import { createStoreSink } from './store-sink';
 import type { LLMRequestInsert, SpanInsert, TraceUpsert } from './types';
 
 describe('createStoreSink', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('flushes the final Node batch with a one-shot timer', async () => {
+    vi.useFakeTimers();
+    const batchInsertRequests = vi.fn(async () => ({ count: 1 }));
+    const store = {
+      batchInsertRequests,
+      batchInsertSpans: vi.fn(async () => ({ count: 0 })),
+      upsertTrace: vi.fn(async () => null),
+    } as unknown as TelemetryStore;
+    const sink = createStoreSink(store, { flushIntervalMs: 25 });
+
+    sink.emit([
+      {
+        type: 'llm_request',
+        request: {
+          requestId: crypto.randomUUID(),
+          provider: 'openai',
+          model: 'gpt-4o-mini',
+          input: {},
+          output: null,
+          status: 'success',
+          startedAt: new Date().toISOString(),
+        },
+      },
+    ]);
+
+    expect(batchInsertRequests).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(25);
+    expect(batchInsertRequests).toHaveBeenCalledOnce();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
   it('preserves the streaming flag on LLM request records', async () => {
     const batchInsertRequests = vi.fn(
       async (_requests: LLMRequestInsert[]) => ({ count: 1 }),

--- a/packages/sdk/src/telemetry/store-sink.ts
+++ b/packages/sdk/src/telemetry/store-sink.ts
@@ -16,7 +16,7 @@ export interface StoreSinkConfig {
    * Edge runtimes (Cloudflare Workers, Vercel Edge): pass
    * `ctx.waitUntil.bind(ctx)`. When provided, the sink flushes in the
    * background tied to the request lifecycle instead of starting a
-   * `setInterval` — which does not run between requests on Workers.
+   * timer — which does not run between requests on Workers.
    */
   waitUntil?: (promise: Promise<unknown>) => void;
 }
@@ -30,19 +30,24 @@ export function createStoreSink(
   const { flushIntervalMs = 2000, maxBatchSize = 100, waitUntil } = config;
 
   let queue: TelemetryEvent[] = [];
-  let timer: ReturnType<typeof setInterval> | null = null;
+  let timer: ReturnType<typeof setTimeout> | null = null;
 
   function ensureTimer(): void {
     // Edge path uses waitUntil (in emit); no background timer needed there.
     if (waitUntil || timer) return;
-    timer = setInterval(() => {
+    // A one-shot, referenced timer lets short-lived Node processes (notably the
+    // eval CLI) persist their last batch before exiting. `flush()` clears it,
+    // so there is no perpetual interval keeping the process alive afterward.
+    timer = setTimeout(() => {
       flush().catch(logFlushError);
     }, flushIntervalMs);
-    // Never keep a short-lived process (e.g. the eval CLI) alive just to flush.
-    (timer as { unref?: () => void }).unref?.();
   }
 
   async function flush(): Promise<void> {
+    if (timer) {
+      clearTimeout(timer);
+      timer = null;
+    }
     if (queue.length === 0) return;
     const batch = queue;
     queue = [];


### PR DESCRIPTION
## Summary

- repair the eval CLI so it typechecks, builds, executes files without shell interpolation, and emits clean JSON (one result or a JSON array)
- fix runner correctness for duplicate datapoints, valid `null` outputs, invalid concurrency, and evaluator failures being reported as passes
- fix `judgeScorer()` interpolation for nested placeholders such as `{{target.answer}}` and `{{data.question}}`
- implement `store.dataset(...)` for Postgres, SQLite, and D1, hydrating production request input/output from linked spans
- replace the Node store sink's unref'd perpetual interval with a one-shot flush timer so short-lived eval processes durably write their final telemetry batch
- document the production-telemetry-to-eval workflow

## Test plan

- [x] frozen install from `pnpm-lock.yaml`
- [x] core typecheck + 22/22 tests
- [x] SDK typecheck + 17/17 tests
- [x] CLI typecheck + build
- [x] gateway typecheck + 16/16 tests
- [x] app build + 12/12 tests
- [x] app typecheck has only the 3 known `src/server/lib/zv.ts` portability nits
- [x] documented support-bot eval runs through the built CLI
- [x] `--json` stdout parses directly with `jq`
- [x] live Postgres dataset converts persisted OpenAI telemetry into hydrated eval datapoints
- [x] real `gpt-4o-mini` judge E2E scores 1.0 and persists its final linked request/span/trace without `waitUntil`, sleeps, or manual flushing

## Live judge result

- 146 input + 25 output tokens
- 37 microdollars
- linked request and trace persisted before the short-lived Node process exited
