### PR TITLE
docs: add AGENTS.md and repair stale feature claims

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,93 @@
+# AGENTS.md
+
+## What This Is
+
+LLMOps is an open-source, pluggable LLMOps toolkit for TypeScript. One SDK that gives you an AI gateway, observability, and evals for every LLM call. UNIX philosophy — each piece does one thing well and composes via typed interfaces.
+
+Website: https://llmops.build
+License: Apache 2.0
+
+## Monorepo Structure
+
+```
+packages/
+├── sdk/              → @llmops/sdk — Public API. Entry point for everything.
+│   ├── telemetry/    → TelemetryStore interface + Postgres store (raw pg, no ORM)
+│   ├── store/        → pg, d1, sqlite store implementations + migrations
+│   ├── eval/         → evaluate(), judgeScorer(), compare()
+│   ├── types/        → TelemetryStore type export
+│   └── lib/          → Hono, Express, Next.js middleware adapters
+├── core/             → @llmops/core — Shared types, Zod schemas, provider registry. Zero database code.
+├── gateway/          → @llmops/gateway — AI Gateway. OpenAI-compatible proxy.
+├── app/              → @llmops/app — Dashboard UI (React + Hono). Workers-compatible.
+└── cli/              → @llmops/cli — CLI for migrations and evals.
+
+docs/                 → Fumadocs site (https://llmops.build/docs)
+examples/             → Example apps (hono, express, nextjs, langchain, eval, cloudflare-worker)
+```
+
+## Tech Stack
+
+- **Language:** TypeScript (strict mode)
+- **Runtime:** Node.js + Cloudflare Workers
+- **Package manager:** pnpm (workspace monorepo)
+- **Build:** tsdown (rolldown-based bundler)
+- **Linting/Formatting:** Biome
+- **Framework compatibility:** Hono, Express, Next.js
+- **Dashboard:** React + Vanilla Extract CSS
+- **Docs:** Fumadocs
+- **SQL:** Raw pg/SQLite (no ORM). Schema managed by tsqx.
+- **Versioning:** bump.config.ts
+
+## How to Work on This Project
+
+```bash
+pnpm install                    # Install all workspace dependencies
+pnpm build                      # Build all packages
+pnpm dev                        # Dev mode
+```
+
+Test changes by running the examples in `examples/`.
+
+Run evals: `cd examples/eval && npx @llmops/cli eval`
+
+## Architecture Principles
+
+1. **UNIX philosophy.** Each package does one thing. Compose via interfaces, not inheritance.
+2. **Adoption-first.** `llmops()` with zero args must work. Every feature is opt-in.
+3. **TypeScript-first.** Strict generics. Compile-time enforcement. No `any`.
+4. **Code-first.** Everything configurable from code. No database-managed configs.
+5. **Framework-agnostic.** The SDK doesn't depend on Hono or Express. Middleware adapters are subpath exports.
+6. **No database code in core.** All SQL lives in `sdk/src/telemetry/` and `sdk/src/store/`. `@llmops/core` has zero database imports. Zero Kysely.
+7. **One SDK, many entrypoints.** Stores, evals, and middleware are subpath exports of `@llmops/sdk`, not separate packages. Heavy deps (pg, better-sqlite3) are peerDependencies.
+8. **Edge-compatible.** The main SDK bundle has no `require()`, no `fileURLToPath`, no `node:fs`. Store subpaths are isolated — Workers never load the pg store.
+
+## Subpath Exports
+
+Everything ships from `@llmops/sdk`. One package, multiple entrypoints:
+
+```
+@llmops/sdk              → Main entry: llmops(), provider config, telemetry types
+@llmops/sdk/store/pg     → pgStore() — peer dep: pg
+@llmops/sdk/store/sqlite → sqliteStore() — peer dep: better-sqlite3
+@llmops/sdk/store/d1     → d1Store() — Cloudflare D1 (no peer dep)
+@llmops/sdk/eval         → evaluate(), judgeScorer(), compare()
+@llmops/sdk/types        → TelemetryStore type
+@llmops/sdk/hono         → Hono middleware
+@llmops/sdk/express      → Express middleware
+@llmops/sdk/nextjs       → Next.js route handler adapter
+@llmops/sdk/agents       → OpenAI Agents SDK tracing exporter
+```
+
+Stores use `peerDependencies` for heavy deps. The main SDK entry has zero Node.js built-ins — safe for Workers bundling.
+
+## Code Conventions
+
+- Strict TypeScript. No `any`. Use generics and inference.
+- Functions over classes. Factory functions that return typed objects.
+- Prefer `interface` for contracts, `type` for unions and intersections.
+- Named exports only. No default exports.
+- Error handling: use `Promise.allSettled` for fan-out. Never let one sink crash the gateway.
+- No `require()` in any bundle that may run on edge. Use dynamic `import()` for Node-only modules.
+- No `fileURLToPath` or `node:fs` at module level in app/SDK. Use lazy loading for dev-only paths.
+- `.sql` files inlined at build time via rolldown plugin. No runtime file I/O.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ packages/
 │   ├── types/        → TelemetryStore type export
 │   └── lib/          → Hono, Express, Next.js middleware adapters
 ├── core/             → @llmops/core — Shared types, Zod schemas, provider registry. Zero database code.
-├── gateway/          → @llmops/gateway — AI Gateway. OpenAI-compatible proxy.
+├── gateway/          → @llmops/gateway — AI Gateway. OpenAI-compatible in-process plug.
 ├── app/              → @llmops/app — Dashboard UI (React + Hono). Workers-compatible.
 └── cli/              → @llmops/cli — CLI for migrations and evals.
 
@@ -55,7 +55,7 @@ Run evals: `cd examples/eval && npx @llmops/cli eval`
 
 1. **UNIX philosophy.** Each package does one thing. Compose via interfaces, not inheritance.
 2. **Adoption-first.** `llmops()` with zero args must work. Every feature is opt-in.
-3. **TypeScript-first.** Strict generics. Compile-time enforcement. No `any`.
+3. **TypeScript-first.** Strict generics. Compile-time enforcement. Prefer `unknown` over `any` in new code; avoid introducing `any` unless an existing package convention requires it.
 4. **Code-first.** Everything configurable from code. No database-managed configs.
 5. **Framework-agnostic.** The SDK doesn't depend on Hono or Express. Middleware adapters are subpath exports.
 6. **No database code in core.** All SQL lives in `sdk/src/telemetry/` and `sdk/src/store/`. `@llmops/core` has zero database imports. Zero Kysely.
@@ -83,10 +83,10 @@ Stores use `peerDependencies` for heavy deps. The main SDK entry has zero Node.j
 
 ## Code Conventions
 
-- Strict TypeScript. No `any`. Use generics and inference.
+- Strict TypeScript. Prefer `unknown` over `any` in new code; avoid introducing `any` unless an existing package convention requires it. Use generics and inference.
 - Functions over classes. Factory functions that return typed objects.
 - Prefer `interface` for contracts, `type` for unions and intersections.
-- Named exports only. No default exports.
+- Prefer named exports. Avoid introducing default exports unless an existing package convention (e.g., Hono app modules, tsqx config files) requires them.
 - Error handling: use `Promise.allSettled` for fan-out. Never let one sink crash the gateway.
 - No `require()` in any bundle that may run on edge. Use dynamic `import()` for Node-only modules.
 - No `fileURLToPath` or `node:fs` at module level in app/SDK. Use lazy loading for dev-only paths.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@ packages/
 └── cli/              → @llmops/cli — CLI for migrations and evals.
 
 docs/                 → Fumadocs site (https://llmops.build/docs)
-examples/             → Example apps (hono, express, nextjs, langchain, eval, cloudflare-worker)
+examples/             → Example apps (eval, express, hono, langchain, nextjs)
 ```
 
 ## Tech Stack

--- a/README.md
+++ b/README.md
@@ -33,11 +33,11 @@ LLMOps is an open-source, pluggable toolkit designed for TypeScript teams to str
 
 ### Key Features
 
-- **Unified Provider Interface**: Support for 70+ LLM providers including OpenAI, Anthropic, Azure, Bedrock, Mistral, and more
-- **OpenAI SDK Compatible**: Drop-in replacement API that works with any OpenAI SDK client - just change the base URL
-- **Prompt Management**: Version, organize, and deploy prompts with a centralized prompt registry
-- **Observability**: Full request/response logging, cost tracking, and performance monitoring
-- **TypeScript-First**: Built with TypeScript for excellent type safety and developer experience
+- **AI Gateway**: OpenAI-compatible API that routes to a broad range of LLM providers. Drop-in replacement — change the base URL and it works with any OpenAI SDK client.
+- **Observability**: Full request/response logging, cost tracking, performance monitoring, and distributed traces with spans.
+- **Telemetry Stores**: Postgres, SQLite, or Cloudflare D1. Raw SQL, no ORM. Migrations run automatically or via CLI.
+- **Evals**: Code-first evaluation with `evaluate()`, `judgeScorer()`, and `compare()`. Results stored as version-controllable JSON files.
+- **TypeScript-First**: Strict-mode TypeScript with excellent type safety and developer experience
 
 Visit our [documentation](https://llmops.build/docs) for detailed setup instructions and examples.
 

--- a/docs/src/routes/api/llms-txt.ts
+++ b/docs/src/routes/api/llms-txt.ts
@@ -53,7 +53,7 @@ LLMOps is a comprehensive LLMOps toolkit that provides an AI Gateway, observabil
 - AI Gateway: OpenAI-compatible API that routes to a broad range of LLM providers
 - Observability: Request/response logging, cost tracking, latency metrics, and distributed traces with spans
 - Telemetry Stores: Postgres, SQLite, or Cloudflare D1 with automatic migrations
-- Evals: Code-first evaluation with `evaluate`, `judgeScorer`, and `compare`
+- Evals: Code-first evaluation with \`evaluate\`, \`judgeScorer\`, and \`compare\`
 - Framework Agnostic: Works with Express, Hono, Next.js, and more
 - TypeScript-First: Strict type safe SDK
 - Self-Hosted: Full control over your data and infrastructure

--- a/docs/src/routes/api/llms-txt.ts
+++ b/docs/src/routes/api/llms-txt.ts
@@ -46,14 +46,15 @@ function generateLLMsText(): string {
 
 > Framework-agnostic, universal LLM operations toolkit for TypeScript
 
-LLMOps is a comprehensive LLMOps toolkit that provides prompt versioning, multi-environment deployments, and an AI Gateway to access 1600+ LLMs from 70+ providers.
+LLMOps is a comprehensive LLMOps toolkit that provides an AI Gateway, observability, telemetry stores, and evals for every LLM call.
 
 ## Features
 
-- AI Gateway: OpenAI-compatible API to access 1600+ LLMs from 70+ providers
-- Prompt Management: Version, test, and deploy prompts with a visual editor
-- Environment Management: Production, staging, development with secure secrets
-- Framework Agnostic: Works with Express, Hono, and more
+- AI Gateway: OpenAI-compatible API that routes to a broad range of LLM providers
+- Observability: Request/response logging, cost tracking, latency metrics, and distributed traces with spans
+- Telemetry Stores: Postgres, SQLite, or Cloudflare D1 with automatic migrations
+- Evals: Code-first evaluation with `evaluate`, `judgeScorer`, and `compare`
+- Framework Agnostic: Works with Express, Hono, Next.js, and more
 - TypeScript-First: Strict type safe SDK
 - Self-Hosted: Full control over your data and infrastructure
 


### PR DESCRIPTION
## Summary

- add a root AGENTS.md with repository structure, verified SDK subpaths, commands, architecture principles, and agent-safe conventions
- remove deleted prompt-management and environment-management claims from README.md and the generated llms.txt route
- replace unsupported provider-count claims with the current gateway, observability, telemetry-store, trace, and eval capabilities
- keep the change documentation-only

## Verification

- git diff --check passes
- every listed SDK subpath was checked against packages/sdk/package.json
- every listed root command was checked against package.json
- docs typecheck confirms the changed llms.txt route compiles; the command still exits on the same three pre-existing TS2820 links to /docs in header.tsx, hero.tsx, and routes/index.tsx
- working tree is clean