### PR TITLE
feat(gateway): instrument OpenAI Responses API

### DIFF
--- a/packages/core/src/telemetry/events.ts
+++ b/packages/core/src/telemetry/events.ts
@@ -18,6 +18,8 @@ export interface TokenUsage {
   outputTokens?: number;
   cacheReadTokens?: number;
   cacheWriteTokens?: number;
+  /** Output tokens used for reasoning (included in outputTokens). */
+  reasoningTokens?: number;
 }
 
 /** A single LLM call — the unit behind the request log and cost tracking. */

--- a/packages/gateway/src/gateway.test.ts
+++ b/packages/gateway/src/gateway.test.ts
@@ -40,6 +40,19 @@ function imageRequest(model: string): Request {
   });
 }
 
+function responsesRequest(model: string): Request {
+  return new Request('http://gateway/api/genai/v1/responses', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      model,
+      input: 'Say hello',
+      stream: true,
+      stream_options: { include_obfuscation: false },
+    }),
+  });
+}
+
 describe('createGateway', () => {
   it('resolves the base URL via the injected getProviderMetadata + Bearer auth + stripped model', async () => {
     const fetchMock = vi.fn(async () => jsonResponse({ id: 'ok' }));
@@ -136,6 +149,37 @@ describe('createGateway', () => {
       response_format: 'b64_json',
       n: 1,
     });
+  });
+
+  it('does not inject Chat Completions stream options into Responses requests', async () => {
+    const fetchMock = vi.fn(async () =>
+      jsonResponse({
+        id: 'resp_1',
+        status: 'completed',
+        output: [],
+        usage: { input_tokens: 2, output_tokens: 1, total_tokens: 3 },
+      }),
+    );
+    const gw = createGateway({
+      providers: [{ provider: 'openai', slug: 'openai', apiKey: 'sk-test' }],
+      getProviderMetadata: metadata,
+      telemetry: { emit: () => {}, flush: async () => {} },
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+
+    const res = await gw(responsesRequest('@openai/gpt-5.4'));
+    expect(res.status).toBe(200);
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://api.openai.com/v1/responses');
+    expect(JSON.parse(init.body as string)).toMatchObject({
+      model: 'gpt-5.4',
+      stream: true,
+      stream_options: { include_obfuscation: false },
+    });
+    expect(JSON.parse(init.body as string).stream_options).not.toHaveProperty(
+      'include_usage',
+    );
   });
 
   it('returns the upstream response body unchanged (pass-through)', async () => {

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -4,6 +4,7 @@ import { parseModel, resolveTarget } from './resolve';
 import { matchRoute } from './router';
 import { resolveGatewayTraceContext } from './trace-context';
 import type { GatewayConfig, ProviderInput } from './types/config';
+import { RequestType } from './types/requests';
 import { errorResponse } from './utils/responses';
 
 /** The in-process gateway handler — a plug you mount, not a proxy you route to. */
@@ -62,13 +63,18 @@ export function createGateway(config: GatewayConfig = {}): GatewayHandler {
     if (!resolved.ok) return errorResponse(resolved.error);
 
     // Strip the `@slug/` prefix so the upstream sees its own bare model id.
-    // When metering a stream, ask OpenAI-compatible providers to include usage
-    // in the final SSE chunk so cost can be computed without buffering.
+    // Chat Completions omits streaming usage unless explicitly requested.
+    // Responses streams carry usage on `response.completed` and define a
+    // different stream_options contract, so never inject include_usage there.
     const rewritten: Record<string, unknown> = {
       ...payload,
       model: parsed.value.model,
     };
-    if (config.telemetry && rewritten.stream === true) {
+    if (
+      config.telemetry &&
+      rewritten.stream === true &&
+      requestType === RequestType.ChatCompletion
+    ) {
       rewritten.stream_options = {
         ...(rewritten.stream_options as Record<string, unknown> | undefined),
         include_usage: true,

--- a/packages/gateway/src/instrument.test.ts
+++ b/packages/gateway/src/instrument.test.ts
@@ -53,6 +53,18 @@ function imageRequest(model: string): Request {
   });
 }
 
+function responsesRequest(model: string, stream = false): Request {
+  return new Request('http://gw/api/genai/v1/responses', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      model,
+      stream,
+      input: [{ role: 'user', content: 'Use the weather tool for Paris' }],
+    }),
+  });
+}
+
 function sseStream(chunks: string[]): ReadableStream<Uint8Array> {
   const enc = new TextEncoder();
   return new ReadableStream({
@@ -279,6 +291,187 @@ describe('gateway telemetry', () => {
       'gen_ai.operation.name': 'image_generation',
       'gen_ai.request.endpoint': '/images/generations',
     });
+  });
+
+  it('meters Responses usage and preserves tool-call linkage without opaque payloads', async () => {
+    const h = harness();
+    const fetchMock = vi.fn(async () =>
+      new Response(
+        JSON.stringify({
+          id: 'resp_123',
+          status: 'completed',
+          output: [
+            {
+              id: 'rs_1',
+              type: 'reasoning',
+              encrypted_content: 'opaque-reasoning-payload',
+              summary: [{ type: 'summary_text', text: 'Check weather' }],
+            },
+            {
+              id: 'fc_1',
+              type: 'function_call',
+              call_id: 'call_weather_1',
+              name: 'get_weather',
+              arguments: '{"city":"Paris"}',
+              status: 'completed',
+            },
+            {
+              id: 'ig_1',
+              type: 'image_generation_call',
+              status: 'completed',
+              result: 'large-base64-image',
+            },
+          ],
+          usage: {
+            input_tokens: 20,
+            output_tokens: 10,
+            total_tokens: 30,
+            input_tokens_details: { cached_tokens: 5 },
+            output_tokens_details: { reasoning_tokens: 4 },
+          },
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      ),
+    );
+    const gw = createGateway({
+      providers: [{ provider: 'openai', slug: 'openai', apiKey: 'k' }],
+      getProviderMetadata: metadata,
+      getModelPricing: pricing,
+      telemetry: h.telemetry as never,
+      waitUntil: h.waitUntil,
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+
+    const res = await gw(responsesRequest('@openai/gpt-5.4'));
+    expect((await res.json()).id).toBe('resp_123');
+    await h.settle();
+
+    expect(h.events[0].request).toMatchObject({
+      endpoint: '/responses',
+      usage: {
+        inputTokens: 20,
+        outputTokens: 10,
+        cacheReadTokens: 5,
+        reasoningTokens: 4,
+      },
+      output: {
+        responseId: 'resp_123',
+        status: 'completed',
+        output: [
+          {
+            id: 'rs_1',
+            type: 'reasoning',
+            summary: [{ type: 'summary_text', text: 'Check weather' }],
+          },
+          {
+            id: 'fc_1',
+            type: 'function_call',
+            call_id: 'call_weather_1',
+            name: 'get_weather',
+            arguments: '{"city":"Paris"}',
+          },
+          {
+            id: 'ig_1',
+            type: 'image_generation_call',
+            result: '[image omitted]',
+          },
+        ],
+      },
+    });
+    expect(JSON.stringify(h.events)).not.toContain('opaque-reasoning-payload');
+    expect(JSON.stringify(h.events)).not.toContain('large-base64-image');
+    expect(h.events[0].request.cost).toBeCloseTo(0.00015);
+    expect(h.events[1].span.attributes).toMatchObject({
+      'gen_ai.operation.name': 'generate_content',
+      'gen_ai.usage.input_tokens': 20,
+      'gen_ai.usage.output_tokens': 10,
+      'llmops.usage.reasoning_tokens': 4,
+    });
+  });
+
+  it('meters typed Responses SSE from response.completed without changing bytes', async () => {
+    const h = harness();
+    const chunks = [
+      'event: response.created\ndata: {"type":"response.created","response":{"id":"resp_stream","status":"in_progress","output":[]}}\n\n',
+      'event: response.output_text.delta\ndata: {"type":"response.output_text.delta","delta":"hello"}\n\n',
+      'event: response.completed\ndata: {"type":"response.completed","response":{"id":"resp_stream","status":"completed","output":[{"id":"msg_1","type":"message","role":"assistant","status":"completed","content":[{"type":"output_text","text":"hello"}]}],"usage":{"input_tokens":12,"output_tokens":3,"total_tokens":15,"output_tokens_details":{"reasoning_tokens":1}}}}\n\n',
+    ];
+    const fetchMock = vi.fn(async () =>
+      new Response(sseStream(chunks), {
+        status: 200,
+        headers: { 'content-type': 'text/event-stream' },
+      }),
+    );
+    const gw = createGateway({
+      providers: [{ provider: 'openai', slug: 'openai', apiKey: 'k' }],
+      getProviderMetadata: metadata,
+      getModelPricing: pricing,
+      telemetry: h.telemetry as never,
+      waitUntil: h.waitUntil,
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+
+    const res = await gw(responsesRequest('@openai/gpt-5.4', true));
+    expect(await res.text()).toBe(chunks.join(''));
+    await h.settle();
+
+    expect(h.events[0].request).toMatchObject({
+      endpoint: '/responses',
+      isStreaming: true,
+      usage: { inputTokens: 12, outputTokens: 3, reasoningTokens: 1 },
+      output: {
+        responseId: 'resp_stream',
+        status: 'completed',
+        output: [
+          {
+            id: 'msg_1',
+            type: 'message',
+            role: 'assistant',
+            content: [{ type: 'output_text', text: 'hello' }],
+          },
+        ],
+      },
+    });
+    expect(h.events[0].request.cost).toBeCloseTo(0.00006);
+
+    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    expect(JSON.parse(init.body as string).stream_options).toBeUndefined();
+  });
+
+  it('records a typed response.failed stream as an error', async () => {
+    const h = harness();
+    const chunks = [
+      'event: response.failed\ndata: {"type":"response.failed","response":{"id":"resp_failed","status":"failed","output":[],"error":{"code":"server_error","message":"model execution failed"},"usage":null}}\n\n',
+    ];
+    const fetchMock = vi.fn(async () =>
+      new Response(sseStream(chunks), {
+        status: 200,
+        headers: { 'content-type': 'text/event-stream' },
+      }),
+    );
+    const gw = createGateway({
+      providers: [{ provider: 'openai', slug: 'openai', apiKey: 'k' }],
+      getProviderMetadata: metadata,
+      telemetry: h.telemetry as never,
+      waitUntil: h.waitUntil,
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+
+    const res = await gw(responsesRequest('@openai/gpt-5.4', true));
+    expect(await res.text()).toBe(chunks.join(''));
+    await h.settle();
+
+    expect(h.events[0].request).toMatchObject({
+      endpoint: '/responses',
+      status: 'error',
+      statusCode: 200,
+      error: 'model execution failed',
+    });
+    expect(h.events[1].span).toMatchObject({
+      status: 'error',
+      error: 'model execution failed',
+    });
+    expect(h.events[1].trace.status).toBe('error');
   });
 
   it('no telemetry configured → same Response, nothing metered', async () => {

--- a/packages/gateway/src/instrument.test.ts
+++ b/packages/gateway/src/instrument.test.ts
@@ -7,6 +7,8 @@ const metadata: ProviderMetadataResolver = async () => ({
   openaiCompatible: true,
 });
 
+const RESPONSES_URL = 'http://gw/api/genai/v1/responses';
+
 // biome-ignore lint/suspicious/noExplicitAny: test stub
 const pricing = async (): Promise<any> => ({
   inputCostPer1M: 2.5,
@@ -54,7 +56,7 @@ function imageRequest(model: string): Request {
 }
 
 function responsesRequest(model: string, stream = false): Request {
-  return new Request('http://gw/api/genai/v1/responses', {
+  return new Request(RESPONSES_URL, {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
     body: JSON.stringify({
@@ -472,6 +474,100 @@ describe('gateway telemetry', () => {
       error: 'model execution failed',
     });
     expect(h.events[1].trace.status).toBe('error');
+  });
+
+  it('meters a non-streaming body with unexpected shapes without throwing (guards narrow, never cast)', async () => {
+    const h = harness();
+    const fetchMock = vi.fn(async () =>
+      new Response(
+        JSON.stringify({
+          id: 42, // wrong type — should be a string
+          data: { not: 'an-array' }, // malformed images payload
+          usage: 'not-an-object',
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      ),
+    );
+    const gw = createGateway({
+      providers: [{ provider: 'openai', slug: 'openai', apiKey: 'k' }],
+      getProviderMetadata: metadata,
+      telemetry: h.telemetry as never,
+      waitUntil: h.waitUntil,
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+
+    const res = await gw(chatRequest('@openai/gpt-4o'));
+    expect(res.status).toBe(200);
+    await h.settle();
+
+    expect(h.events).toHaveLength(2);
+    expect(h.events[0].request).toMatchObject({
+      status: 'success',
+      output: null,
+    });
+    expect(h.events[0].request.usage).toBeUndefined();
+  });
+
+  it('skips a malformed SSE data frame without throwing and still meters the valid one', async () => {
+    const h = harness();
+    const chunks = [
+      'data: {not valid json at all\n\n',
+      'data: {"choices":[],"usage":{"prompt_tokens":10,"completion_tokens":5}}\n\n',
+      'data: [DONE]\n\n',
+    ];
+    const fetchMock = vi.fn(async () =>
+      new Response(sseStream(chunks), {
+        status: 200,
+        headers: { 'content-type': 'text/event-stream' },
+      }),
+    );
+    const gw = createGateway({
+      providers: [{ provider: 'openai', slug: 'openai', apiKey: 'k' }],
+      getProviderMetadata: metadata,
+      telemetry: h.telemetry as never,
+      waitUntil: h.waitUntil,
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+
+    const res = await gw(chatRequest('@openai/gpt-4o', true));
+    expect(await res.text()).toBe(chunks.join('')); // caller received every byte
+    await h.settle();
+
+    expect(h.events[0].request.usage).toMatchObject({
+      inputTokens: 10,
+      outputTokens: 5,
+    });
+    expect(h.events[0].request.status).toBe('success');
+  });
+
+  it('meters usage from an incomplete final SSE frame (no trailing blank line)', async () => {
+    const h = harness();
+    const chunks = [
+      'data: {"choices":[{"delta":{"content":"hi"}}]}\n\n',
+      'data: {"choices":[],"usage":{"prompt_tokens":7,"completion_tokens":3}}',
+    ];
+    const fetchMock = vi.fn(async () =>
+      new Response(sseStream(chunks), {
+        status: 200,
+        headers: { 'content-type': 'text/event-stream' },
+      }),
+    );
+    const gw = createGateway({
+      providers: [{ provider: 'openai', slug: 'openai', apiKey: 'k' }],
+      getProviderMetadata: metadata,
+      telemetry: h.telemetry as never,
+      waitUntil: h.waitUntil,
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+
+    const res = await gw(chatRequest('@openai/gpt-4o', true));
+    expect(await res.text()).toBe(chunks.join(''));
+    await h.settle();
+
+    expect(h.events[0].request.usage).toMatchObject({
+      inputTokens: 7,
+      outputTokens: 3,
+    });
   });
 
   it('no telemetry configured → same Response, nothing metered', async () => {

--- a/packages/gateway/src/instrument.ts
+++ b/packages/gateway/src/instrument.ts
@@ -7,10 +7,19 @@ import type {
   TraceRecord,
 } from '@llmops/core';
 import {
+  type OpenAIResponseBody,
+  type OpenAIUsage,
+  parseOpenAIResponseBody,
+  parseSSEEventPayload,
+} from './openai-protocol';
+import {
   applyTraceHeaders,
   type GatewayTraceContext,
 } from './trace-context';
 import { RequestType } from './types/requests';
+
+/** The status telemetry records for a metered request — never an arbitrary string. */
+type MeteringStatus = 'success' | 'error';
 
 export interface InstrumentContext {
   telemetry: TelemetrySink;
@@ -99,31 +108,21 @@ async function meterJson(
   cloned: Response,
   statusCode: number,
 ): Promise<void> {
-  const body = (await cloned.json()) as OpenAIResponseBody;
+  const body = parseOpenAIResponseBody(await cloned.json());
   const failed =
     ctx.requestType === RequestType.Responses && body.status === 'failed';
   await emit(
     ctx,
     toTokenUsage(body.usage),
     extractJsonOutput(body),
-    failed ? 'error' : 'success',
+    toMeteringStatus(failed),
     statusCode,
     failed ? responseErrorMessage(body) : undefined,
   );
 }
 
-interface OpenAIResponseBody {
-  id?: string;
-  status?: string;
-  error?: { message?: string; code?: string } | null;
-  usage?: OpenAIUsage | null;
-  choices?: Array<{ message?: unknown }>;
-  data?: Array<{
-    b64_json?: string;
-    url?: string;
-    revised_prompt?: string;
-  }>;
-  output?: unknown[];
+function toMeteringStatus(failed: boolean): MeteringStatus {
+  return failed ? 'error' : 'success';
 }
 
 function extractJsonOutput(body: OpenAIResponseBody): unknown {
@@ -150,16 +149,30 @@ function extractJsonOutput(body: OpenAIResponseBody): unknown {
   };
 }
 
+/** Recursive shape of `sanitizeResponseOutput` — mirrors the sanitized subset of
+ * the untyped `output` payload, with binary/opaque fields replaced by markers. */
+type SanitizedOutput =
+  | string
+  | number
+  | boolean
+  | null
+  | undefined
+  | SanitizedOutput[]
+  | { [key: string]: SanitizedOutput };
+
 /** Preserve agent/tool linkage while excluding opaque or binary payloads. */
-function sanitizeResponseOutput(value: unknown, parentType?: string): unknown {
+function sanitizeResponseOutput(
+  value: unknown,
+  parentType?: string,
+): SanitizedOutput {
   if (Array.isArray(value)) {
     return value.map((item) => sanitizeResponseOutput(item, parentType));
   }
-  if (!value || typeof value !== 'object') return value;
+  if (!value || typeof value !== 'object') return value as SanitizedOutput;
 
   const source = value as Record<string, unknown>;
   const type = typeof source.type === 'string' ? source.type : parentType;
-  const sanitized: Record<string, unknown> = {};
+  const sanitized: Record<string, SanitizedOutput> = {};
   for (const [key, entry] of Object.entries(source)) {
     if (key === 'encrypted_content') continue;
     if (key === 'b64_json' || key === 'screenshot') {
@@ -199,7 +212,7 @@ async function emit(
   ctx: InstrumentContext,
   usage: TokenUsage | undefined,
   output: unknown,
-  status: 'success' | 'error',
+  status: MeteringStatus,
   statusCode: number,
   error?: string,
 ): Promise<void> {
@@ -320,17 +333,6 @@ async function computeCostDollars(
 }
 
 // ── OpenAI usage parsing ────────────────────────────────────────────────────
-interface OpenAIUsage {
-  prompt_tokens?: number;
-  completion_tokens?: number;
-  input_tokens?: number;
-  output_tokens?: number;
-  total_tokens?: number;
-  prompt_tokens_details?: { cached_tokens?: number };
-  input_tokens_details?: { cached_tokens?: number };
-  output_tokens_details?: { reasoning_tokens?: number };
-}
-
 function toTokenUsage(
   u: OpenAIUsage | null | undefined,
 ): TokenUsage | undefined {
@@ -359,8 +361,21 @@ function toTokenUsage(
 interface StreamMeteringResult {
   usage?: TokenUsage;
   output?: unknown;
-  status: 'success' | 'error';
+  status: MeteringStatus;
   error?: string;
+}
+
+/** Fold a per-frame metering result into the running stream total. Later
+ * frames win — the terminal `response.completed` / usage chunk overrides
+ * anything an earlier frame (e.g. a delta) reported. */
+function mergeMeteringResult(
+  target: StreamMeteringResult,
+  found: StreamMeteringResult,
+): void {
+  if (found.usage) target.usage = found.usage;
+  if (found.output !== undefined) target.output = found.output;
+  if (found.status === 'error') target.status = 'error';
+  if (found.error) target.error = found.error;
 }
 
 async function drainSSE(
@@ -371,14 +386,6 @@ async function drainSSE(
   let buffer = '';
   const result: StreamMeteringResult = { status: 'success' };
 
-  const consumeFrame = (frame: string) => {
-    const found = parseMeteringFrame(frame);
-    if (found.usage) result.usage = found.usage;
-    if (found.output !== undefined) result.output = found.output;
-    if (found.status === 'error') result.status = 'error';
-    if (found.error) result.error = found.error;
-  };
-
   try {
     while (true) {
       const { done, value } = await reader.read();
@@ -386,13 +393,15 @@ async function drainSSE(
       buffer += decoder.decode(value, { stream: true });
       let sep = buffer.indexOf('\n\n');
       while (sep !== -1) {
-        consumeFrame(buffer.slice(0, sep));
+        mergeMeteringResult(result, parseMeteringFrame(buffer.slice(0, sep)));
         buffer = buffer.slice(sep + 2);
         sep = buffer.indexOf('\n\n');
       }
     }
     buffer += decoder.decode();
-    if (buffer.trim()) consumeFrame(buffer);
+    if (buffer.trim()) {
+      mergeMeteringResult(result, parseMeteringFrame(buffer));
+    }
   } finally {
     reader.releaseLock();
   }
@@ -407,13 +416,7 @@ function parseMeteringFrame(frame: string): StreamMeteringResult {
     const data = trimmed.slice(5).trim();
     if (data === '' || data === '[DONE]') continue;
     try {
-      const json = JSON.parse(data) as {
-        type?: string;
-        message?: string;
-        error?: { message?: string; code?: string };
-        usage?: OpenAIUsage;
-        response?: OpenAIResponseBody;
-      };
+      const json = parseSSEEventPayload(JSON.parse(data));
       const response = json.response;
       const usage = toTokenUsage(response?.usage ?? json.usage);
       if (usage) result.usage = usage;

--- a/packages/gateway/src/instrument.ts
+++ b/packages/gateway/src/instrument.ts
@@ -99,32 +99,42 @@ async function meterJson(
   cloned: Response,
   statusCode: number,
 ): Promise<void> {
-  const body = (await cloned.json()) as {
-    usage?: OpenAIUsage;
-    choices?: Array<{ message?: unknown }>;
-    data?: Array<{
-      b64_json?: string;
-      url?: string;
-      revised_prompt?: string;
-    }>;
-  };
+  const body = (await cloned.json()) as OpenAIResponseBody;
+  const failed =
+    ctx.requestType === RequestType.Responses && body.status === 'failed';
   await emit(
     ctx,
     toTokenUsage(body.usage),
     extractJsonOutput(body),
-    'success',
+    failed ? 'error' : 'success',
     statusCode,
+    failed ? responseErrorMessage(body) : undefined,
   );
 }
 
-function extractJsonOutput(body: {
+interface OpenAIResponseBody {
+  id?: string;
+  status?: string;
+  error?: { message?: string; code?: string } | null;
+  usage?: OpenAIUsage | null;
   choices?: Array<{ message?: unknown }>;
   data?: Array<{
     b64_json?: string;
     url?: string;
     revised_prompt?: string;
   }>;
-}): unknown {
+  output?: unknown[];
+}
+
+function extractJsonOutput(body: OpenAIResponseBody): unknown {
+  if (body.output) {
+    return {
+      responseId: body.id,
+      status: body.status,
+      output: sanitizeResponseOutput(body.output),
+    };
+  }
+
   const message = body.choices?.[0]?.message;
   if (message !== undefined) return message;
   if (!body.data) return null;
@@ -140,17 +150,48 @@ function extractJsonOutput(body: {
   };
 }
 
+/** Preserve agent/tool linkage while excluding opaque or binary payloads. */
+function sanitizeResponseOutput(value: unknown, parentType?: string): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => sanitizeResponseOutput(item, parentType));
+  }
+  if (!value || typeof value !== 'object') return value;
+
+  const source = value as Record<string, unknown>;
+  const type = typeof source.type === 'string' ? source.type : parentType;
+  const sanitized: Record<string, unknown> = {};
+  for (const [key, entry] of Object.entries(source)) {
+    if (key === 'encrypted_content') continue;
+    if (key === 'b64_json' || key === 'screenshot') {
+      sanitized[key] = '[binary omitted]';
+      continue;
+    }
+    if (key === 'result' && type === 'image_generation_call') {
+      sanitized[key] = '[image omitted]';
+      continue;
+    }
+    sanitized[key] = sanitizeResponseOutput(entry, type);
+  }
+  return sanitized;
+}
+
+function responseErrorMessage(body: OpenAIResponseBody): string {
+  return body.error?.message ?? body.error?.code ?? 'response failed';
+}
+
 async function meterStream(
   ctx: InstrumentContext,
   stream: ReadableStream<Uint8Array>,
   statusCode: number,
 ): Promise<void> {
+  const metered = await drainSSE(stream);
   await emit(
     ctx,
-    await drainSSEUsage(stream),
-    undefined,
-    'success',
+    metered.usage,
+    metered.output,
+    metered.status,
     statusCode,
+    metered.error,
   );
 }
 
@@ -183,6 +224,24 @@ async function emit(
     error,
     startedAt: ctx.startedAt,
   };
+  const attributes: Record<string, unknown> = {
+    'gen_ai.operation.name': operationName(ctx.requestType),
+    'gen_ai.provider.name': ctx.provider,
+    'gen_ai.request.model': ctx.model,
+    'gen_ai.request.endpoint': ctx.requestType,
+    'llmops.request.id': ctx.requestId,
+    'llmops.is_streaming': ctx.isStreaming,
+  };
+  if (usage?.inputTokens != null) {
+    attributes['gen_ai.usage.input_tokens'] = usage.inputTokens;
+  }
+  if (usage?.outputTokens != null) {
+    attributes['gen_ai.usage.output_tokens'] = usage.outputTokens;
+  }
+  if (usage?.reasoningTokens != null) {
+    attributes['llmops.usage.reasoning_tokens'] = usage.reasoningTokens;
+  }
+
   const span: SpanRecord = {
     traceId: ctx.trace.traceId,
     spanId: ctx.trace.spanId,
@@ -195,14 +254,7 @@ async function emit(
     cost,
     status: status === 'success' ? 'ok' : 'error',
     error,
-    attributes: {
-      'gen_ai.operation.name': operationName(ctx.requestType),
-      'gen_ai.provider.name': ctx.provider,
-      'gen_ai.request.model': ctx.model,
-      'gen_ai.request.endpoint': ctx.requestType,
-      'llmops.request.id': ctx.requestId,
-      'llmops.is_streaming': ctx.isStreaming,
-    },
+    attributes,
     startedAt: ctx.startedAt,
     endedAt,
   };
@@ -223,6 +275,8 @@ async function emit(
 
 function operationName(requestType: RequestType): string {
   switch (requestType) {
+    case RequestType.Responses:
+      return 'generate_content';
     case RequestType.ImageGeneration:
     case RequestType.ImageEdit:
     case RequestType.ImageVariation:
@@ -269,35 +323,62 @@ async function computeCostDollars(
 interface OpenAIUsage {
   prompt_tokens?: number;
   completion_tokens?: number;
+  input_tokens?: number;
+  output_tokens?: number;
   total_tokens?: number;
   prompt_tokens_details?: { cached_tokens?: number };
+  input_tokens_details?: { cached_tokens?: number };
+  output_tokens_details?: { reasoning_tokens?: number };
 }
 
-function toTokenUsage(u: OpenAIUsage | undefined): TokenUsage | undefined {
+function toTokenUsage(
+  u: OpenAIUsage | null | undefined,
+): TokenUsage | undefined {
   if (!u) return undefined;
-  const inputTokens = u.prompt_tokens ?? 0;
+  const inputTokens = u.input_tokens ?? u.prompt_tokens ?? 0;
+  const reportedOutput = u.output_tokens ?? u.completion_tokens ?? 0;
   const outputTokens = Math.max(
-    u.completion_tokens ?? 0,
+    reportedOutput,
     (u.total_tokens ?? 0) - inputTokens,
   );
   return {
     inputTokens,
     outputTokens,
-    cacheReadTokens: u.prompt_tokens_details?.cached_tokens,
+    cacheReadTokens:
+      u.input_tokens_details?.cached_tokens ??
+      u.prompt_tokens_details?.cached_tokens,
+    reasoningTokens: u.output_tokens_details?.reasoning_tokens,
   };
 }
 
 /**
- * Drain an OpenAI SSE stream and return usage from the terminal chunk (present
- * when `stream_options.include_usage` was set). Frames are `\n\n`-delimited.
+ * Drain an OpenAI SSE stream. Chat Completions exposes top-level usage in its
+ * terminal chunk; Responses exposes a full response (usage + output items) in
+ * the typed `response.completed` event. Frames are `\n\n`-delimited.
  */
-async function drainSSEUsage(
+interface StreamMeteringResult {
+  usage?: TokenUsage;
+  output?: unknown;
+  status: 'success' | 'error';
+  error?: string;
+}
+
+async function drainSSE(
   stream: ReadableStream<Uint8Array>,
-): Promise<TokenUsage | undefined> {
+): Promise<StreamMeteringResult> {
   const reader = stream.getReader();
   const decoder = new TextDecoder();
   let buffer = '';
-  let usage: TokenUsage | undefined;
+  const result: StreamMeteringResult = { status: 'success' };
+
+  const consumeFrame = (frame: string) => {
+    const found = parseMeteringFrame(frame);
+    if (found.usage) result.usage = found.usage;
+    if (found.output !== undefined) result.output = found.output;
+    if (found.status === 'error') result.status = 'error';
+    if (found.error) result.error = found.error;
+  };
+
   try {
     while (true) {
       const { done, value } = await reader.read();
@@ -305,30 +386,49 @@ async function drainSSEUsage(
       buffer += decoder.decode(value, { stream: true });
       let sep = buffer.indexOf('\n\n');
       while (sep !== -1) {
-        const found = parseUsageFrame(buffer.slice(0, sep));
-        if (found) usage = found;
+        consumeFrame(buffer.slice(0, sep));
         buffer = buffer.slice(sep + 2);
         sep = buffer.indexOf('\n\n');
       }
     }
+    buffer += decoder.decode();
+    if (buffer.trim()) consumeFrame(buffer);
   } finally {
     reader.releaseLock();
   }
-  return usage;
+  return result;
 }
 
-function parseUsageFrame(frame: string): TokenUsage | undefined {
+function parseMeteringFrame(frame: string): StreamMeteringResult {
+  const result: StreamMeteringResult = { status: 'success' };
   for (const line of frame.split('\n')) {
     const trimmed = line.trim();
     if (!trimmed.startsWith('data:')) continue;
     const data = trimmed.slice(5).trim();
     if (data === '' || data === '[DONE]') continue;
     try {
-      const json = JSON.parse(data) as { usage?: OpenAIUsage };
-      if (json.usage) return toTokenUsage(json.usage);
+      const json = JSON.parse(data) as {
+        type?: string;
+        message?: string;
+        error?: { message?: string; code?: string };
+        usage?: OpenAIUsage;
+        response?: OpenAIResponseBody;
+      };
+      const response = json.response;
+      const usage = toTokenUsage(response?.usage ?? json.usage);
+      if (usage) result.usage = usage;
+      if (response?.output) result.output = extractJsonOutput(response);
+      if (json.type === 'response.failed' || json.type === 'error') {
+        result.status = 'error';
+        result.error =
+          response?.error?.message ??
+          json.error?.message ??
+          json.message ??
+          'response stream failed';
+      }
     } catch {
       // not JSON — skip
     }
   }
-  return undefined;
+  return result;
 }

--- a/packages/gateway/src/openai-protocol.ts
+++ b/packages/gateway/src/openai-protocol.ts
@@ -1,0 +1,140 @@
+/**
+ * Untrusted-JSON boundary for OpenAI (and OpenAI-compatible) response bodies.
+ *
+ * Upstream JSON — whether a non-streaming body or an SSE `data:` payload — is
+ * never blindly cast. Every field is narrowed with a runtime guard so a
+ * malformed or divergent payload degrades telemetry (missing fields) instead
+ * of throwing into the metering path.
+ */
+
+export interface OpenAIUsage {
+  prompt_tokens?: number;
+  completion_tokens?: number;
+  input_tokens?: number;
+  output_tokens?: number;
+  total_tokens?: number;
+  prompt_tokens_details?: { cached_tokens?: number };
+  input_tokens_details?: { cached_tokens?: number };
+  output_tokens_details?: { reasoning_tokens?: number };
+}
+
+export interface OpenAIResponseBody {
+  id?: string;
+  status?: string;
+  error?: { message?: string; code?: string } | null;
+  usage?: OpenAIUsage | null;
+  choices?: Array<{ message?: unknown }>;
+  data?: Array<{
+    b64_json?: string;
+    url?: string;
+    revised_prompt?: string;
+  }>;
+  output?: unknown[];
+}
+
+/** A single parsed `data:` payload from an OpenAI-compatible SSE stream. */
+export interface SSEEventPayload {
+  type?: string;
+  message?: string;
+  error?: { message?: string; code?: string };
+  usage?: OpenAIUsage;
+  response?: OpenAIResponseBody;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined;
+}
+
+function asNumber(value: unknown): number | undefined {
+  return typeof value === 'number' ? value : undefined;
+}
+
+function asArray(value: unknown): unknown[] | undefined {
+  return Array.isArray(value) ? value : undefined;
+}
+
+function parseErrorField(
+  value: unknown,
+): { message?: string; code?: string } | undefined {
+  if (!isRecord(value)) return undefined;
+  return { message: asString(value.message), code: asString(value.code) };
+}
+
+function parseChoices(value: unknown): OpenAIResponseBody['choices'] {
+  const arr = asArray(value);
+  if (!arr) return undefined;
+  return arr.map((item) => ({
+    message: isRecord(item) ? item.message : undefined,
+  }));
+}
+
+function parseImageData(value: unknown): OpenAIResponseBody['data'] {
+  const arr = asArray(value);
+  if (!arr) return undefined;
+  return arr.map((item) =>
+    isRecord(item)
+      ? {
+          b64_json: asString(item.b64_json),
+          url: asString(item.url),
+          revised_prompt: asString(item.revised_prompt),
+        }
+      : {},
+  );
+}
+
+/** Narrow an untrusted parsed-JSON value into an `OpenAIUsage`. */
+export function parseOpenAIUsage(value: unknown): OpenAIUsage | undefined {
+  if (!isRecord(value)) return undefined;
+  const promptDetails = value.prompt_tokens_details;
+  const inputDetails = value.input_tokens_details;
+  const outputDetails = value.output_tokens_details;
+  return {
+    prompt_tokens: asNumber(value.prompt_tokens),
+    completion_tokens: asNumber(value.completion_tokens),
+    input_tokens: asNumber(value.input_tokens),
+    output_tokens: asNumber(value.output_tokens),
+    total_tokens: asNumber(value.total_tokens),
+    prompt_tokens_details: isRecord(promptDetails)
+      ? { cached_tokens: asNumber(promptDetails.cached_tokens) }
+      : undefined,
+    input_tokens_details: isRecord(inputDetails)
+      ? { cached_tokens: asNumber(inputDetails.cached_tokens) }
+      : undefined,
+    output_tokens_details: isRecord(outputDetails)
+      ? { reasoning_tokens: asNumber(outputDetails.reasoning_tokens) }
+      : undefined,
+  };
+}
+
+/** Narrow an untrusted parsed-JSON value into an `OpenAIResponseBody`. */
+export function parseOpenAIResponseBody(value: unknown): OpenAIResponseBody {
+  if (!isRecord(value)) return {};
+  return {
+    id: asString(value.id),
+    status: asString(value.status),
+    error: value.error === null ? null : parseErrorField(value.error),
+    usage: value.usage === null ? null : parseOpenAIUsage(value.usage),
+    choices: parseChoices(value.choices),
+    data: parseImageData(value.data),
+    output: asArray(value.output),
+  };
+}
+
+/** Narrow an untrusted parsed-JSON SSE `data:` payload into an `SSEEventPayload`. */
+export function parseSSEEventPayload(value: unknown): SSEEventPayload {
+  if (!isRecord(value)) return {};
+  return {
+    type: asString(value.type),
+    message: asString(value.message),
+    error: parseErrorField(value.error),
+    usage: parseOpenAIUsage(value.usage),
+    response:
+      value.response === undefined
+        ? undefined
+        : parseOpenAIResponseBody(value.response),
+  };
+}


### PR DESCRIPTION
## Summary

- meter native Responses API usage for JSON responses and typed SSE response.completed events
- preserve response output items for agent and tool-call debugging while omitting encrypted reasoning and binary image payloads
- record cached and reasoning token details plus generate_content span attributes
- mark typed response.failed streams as telemetry errors
- stop injecting Chat Completions include_usage into Responses stream options

## Verification

- core typecheck and 22/22 tests
- gateway typecheck and 20/20 tests
- SDK typecheck
- core and gateway builds
- gateway runtime bundle contains zero runtime @llmops/core references
- app typecheck reaches only the three pre-existing packages/app/src/server/lib/zv.ts TS2742 portability errors