### PR TITLE
feat(eval): add regression gates and pull-request CI

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -28,11 +28,13 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      # Workspace packages resolve each other's published type declarations
+      # from dist. Build in topological order first on a clean runner.
+      - name: Build
+        run: pnpm run build
+
       - name: Typecheck
         run: pnpm run typecheck
 
       - name: Test
         run: pnpm run test
-
-      - name: Build
-        run: pnpm run build

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,0 +1,38 @@
+name: Pull Request
+
+on:
+  pull_request:
+
+concurrency:
+  group: pr-${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck
+        run: pnpm run typecheck
+
+      - name: Test
+        run: pnpm run test
+
+      - name: Build
+        run: pnpm run build

--- a/examples/eval/README.md
+++ b/examples/eval/README.md
@@ -29,6 +29,35 @@ pnpm eval:json
 The command writes only valid JSON to stdout in this mode, so it can be piped
 directly to tools such as `jq`.
 
+## CI regression gates
+
+Use `--minScore` and `--baseline` to turn a run into a pass/fail gate for pull-request CI —
+no LLM API keys required if your evaluators are deterministic (see `support-bot.eval.ts`).
+
+```bash
+# Fail if an evaluator's mean score drops below a threshold
+npx @llmops/cli eval --minScore "exactMatch=0.8"
+
+# Fail if any evaluator regresses vs a checked-in (or artifact-downloaded) baseline
+npx @llmops/cli eval --baseline ./llmops-evals-baseline
+
+# Allow a small tolerance on regressions instead of an exact match
+npx @llmops/cli eval --baseline ./llmops-evals-baseline --maxRegression 0.02
+```
+
+Exit code `0` means every check passed, `2` means a threshold or regression check failed,
+and `1` means an eval file itself failed to run or the flags were misconfigured — a CI step
+can branch on the exit code directly:
+
+```yaml
+- name: Run eval gate
+  run: npx @llmops/cli eval --minScore "exactMatch=0.8" --baseline ./llmops-evals-baseline
+```
+
+With `--json`, the gate result is embedded alongside the eval results as
+`{ "results": ..., "gate": { "passed": true, "checks": [...] } }`, so an agent or script can
+inspect exactly which evaluator failed and by how much instead of only seeing the exit code.
+
 ## Evaluate production traffic
 
 Every telemetry store can turn persisted requests into the same dataset shape

--- a/examples/eval/README.md
+++ b/examples/eval/README.md
@@ -55,9 +55,10 @@ invalid. A CI step can branch on the exit code directly:
 ```
 
 The gate fails closed: a threshold naming an evaluator that never ran, a baseline eval with
-no counterpart in this run, an eval that recorded errors, or a gate that checked nothing all
-fail rather than passing quietly. Thresholds and `--maxRegression` must be finite values in
-`[0, 1]`, and are validated before any eval executes.
+no counterpart in this run, an evaluator the baseline scored that this run dropped, an eval
+that recorded errors, or a gate that checked nothing all fail rather than passing quietly.
+Evaluators that only exist in the current run count as new coverage and pass. Thresholds and
+`--maxRegression` must be finite values in `[0, 1]`, and are validated before any eval executes.
 
 With `--json`, the gate result is embedded alongside the eval results as
 `{ "results": ..., "gate": { "passed": true, "checks": [...] } }`, so an agent or script can

--- a/examples/eval/README.md
+++ b/examples/eval/README.md
@@ -45,14 +45,19 @@ npx @llmops/cli eval --baseline ./llmops-evals-baseline
 npx @llmops/cli eval --baseline ./llmops-evals-baseline --maxRegression 0.02
 ```
 
-Exit code `0` means every check passed, `2` means a threshold or regression check failed,
-and `1` means an eval file itself failed to run or the flags were misconfigured — a CI step
-can branch on the exit code directly:
+Exit code `0` means the gate ran and every check passed, `2` means a check failed, and `1`
+means the run could not be gated at all — an eval failed to run, or the configuration was
+invalid. A CI step can branch on the exit code directly:
 
 ```yaml
 - name: Run eval gate
   run: npx @llmops/cli eval --minScore "exactMatch=0.8" --baseline ./llmops-evals-baseline
 ```
+
+The gate fails closed: a threshold naming an evaluator that never ran, a baseline eval with
+no counterpart in this run, an eval that recorded errors, or a gate that checked nothing all
+fail rather than passing quietly. Thresholds and `--maxRegression` must be finite values in
+`[0, 1]`, and are validated before any eval executes.
 
 With `--json`, the gate result is embedded alongside the eval results as
 `{ "results": ..., "gate": { "passed": true, "checks": [...] } }`, so an agent or script can

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -84,7 +84,8 @@
     "react-aria-components": "^1.13.0",
     "react-hook-form": "^7.68.0",
     "recharts": "^3.6.0",
-    "uuid": "^13.0.0"
+    "uuid": "^13.0.0",
+    "zod": "^4.3.5"
   },
   "peerDependencies": {
     "react": "^19.2.1",

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -8,3 +8,45 @@
         LLMOps
     </h2>
 </p>
+
+## `llmops eval`
+
+Runs `*.eval.ts` / `*.eval.js` files (see `@llmops/sdk/eval`) and saves results as JSON.
+
+```bash
+npx @llmops/cli eval [flags]
+```
+
+| Flag | Alias | Description |
+| --- | --- | --- |
+| `--target` | `-t` | File or directory to run. Default: `./evals` |
+| `--outputDir` | `-o` | Output directory for results. Default: `./llmops-evals` |
+| `--json` | `-j` | Output results as JSON to stdout |
+| `--minScore` | `-m` | Fail if an evaluator's mean score is below a threshold. Format: `"evaluator=threshold[,evaluator=threshold...]"` |
+| `--baseline` | `-b` | Directory of baseline eval results (e.g. a previous run's `--outputDir`) to check for score regressions |
+| `--maxRegression` | `-r` | Max allowed drop in an evaluator's mean score vs `--baseline` before failing. Requires `--baseline`. Default: `0` (no regression allowed) |
+
+### CI gates
+
+`--minScore` and `--baseline` turn `eval` into a regression gate for CI:
+
+```bash
+# Fail if the accuracy evaluator's mean score drops below 0.8
+npx @llmops/cli eval --minScore "accuracy=0.8"
+
+# Fail if any evaluator regresses vs a baseline results directory
+npx @llmops/cli eval --baseline ./llmops-evals-baseline
+
+# Combine both, allowing a small tolerance on regressions
+npx @llmops/cli eval --minScore "accuracy=0.8" --baseline ./llmops-evals-baseline --maxRegression 0.02
+```
+
+Exit codes are deterministic, so a CI step can gate on them directly:
+
+- `0` — every eval ran and every gate check passed
+- `1` — an eval file failed to run (bundle/execution error), or the flags were misconfigured (e.g. a bad `--minScore` spec, a missing `--baseline` directory)
+- `2` — every eval ran, but a `--minScore` threshold or `--baseline` regression check failed
+
+With `--json`, stdout stays a single parseable JSON document. Without any gate flags it's the eval result(s), unchanged. With `--minScore` and/or `--baseline` set, it's wrapped as `{ "results": ..., "gate": { "passed": boolean, "checks": [...] } }` — safe to pipe to `jq` either way.
+
+The gate itself is also available as a plain function for use outside the CLI — see `applyGate()` in `@llmops/sdk/eval`.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -53,13 +53,16 @@ A gate reports success only when it actually verified something. These all **fai
 
 - an evaluator named in `--minScore` that appears in no result (typo, renamed evaluator)
 - a baseline eval with no matching eval in the current run (renamed or deleted eval)
+- an evaluator the baseline scored that the current run does not — deleting a `safety` evaluator must not read as "no regression" just because the evaluators that remain still pass
 - an eval that recorded datapoint or evaluator errors — a failed datapoint scores 0 and can otherwise drag a mean into looking fine, or be excluded and make it look better than it is
 - a gate that ended up performing zero checks
+
+Evaluators that exist only in the current run are treated as new coverage and pass silently, so adding an evaluator never fails a gate.
 
 Invalid configuration is deliberately separated from a failed gate: `1` means "this gate could not be trusted to run", `2` means "it ran and something regressed". Configuration is validated up front, before any eval executes, so a typo does not cost a full (and possibly paid) eval run.
 
 #### JSON output
 
-With `--json`, stdout stays a single parseable JSON document. Without any gate flags it's the eval result(s), unchanged. With `--minScore` and/or `--baseline` set, it's wrapped as `{ "results": ..., "gate": { "passed": boolean, "checks": [...] } }` — safe to pipe to `jq` either way. Each entry in `checks` carries its `type` (`min-score`, `regression`, `baseline-missing`, `errors`), the numbers behind the verdict, and a `message` when it failed closed.
+With `--json`, stdout stays a single parseable JSON document. Without any gate flags it's the eval result(s), unchanged. With `--minScore` and/or `--baseline` set, it's wrapped as `{ "results": ..., "gate": { "passed": boolean, "checks": [...] } }` — safe to pipe to `jq` either way. Each entry in `checks` carries its `type` (`min-score`, `regression`, `baseline-missing`, `evaluator-missing`, `errors`), the numbers behind the verdict, and a `message` when it failed closed.
 
 The gate itself is also available as a plain function for use outside the CLI — see `applyGate()` in `@llmops/sdk/eval`, which throws on invalid configuration and returns the same `checks` array.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -22,9 +22,9 @@ npx @llmops/cli eval [flags]
 | `--target` | `-t` | File or directory to run. Default: `./evals` |
 | `--outputDir` | `-o` | Output directory for results. Default: `./llmops-evals` |
 | `--json` | `-j` | Output results as JSON to stdout |
-| `--minScore` | `-m` | Fail if an evaluator's mean score is below a threshold. Format: `"evaluator=threshold[,evaluator=threshold...]"` |
+| `--minScore` | `-m` | Fail if an evaluator's mean score is below a threshold. Format: `"evaluator=threshold[,evaluator=threshold...]"`. Thresholds must be finite and in `[0, 1]` |
 | `--baseline` | `-b` | Directory of baseline eval results (e.g. a previous run's `--outputDir`) to check for score regressions |
-| `--maxRegression` | `-r` | Max allowed drop in an evaluator's mean score vs `--baseline` before failing. Requires `--baseline`. Default: `0` (no regression allowed) |
+| `--maxRegression` | `-r` | Max allowed drop in an evaluator's mean score vs `--baseline` before failing. Requires `--baseline`. Must be finite and in `[0, 1]`. Default: `0` (no regression allowed) |
 
 ### CI gates
 
@@ -43,10 +43,23 @@ npx @llmops/cli eval --minScore "accuracy=0.8" --baseline ./llmops-evals-baselin
 
 Exit codes are deterministic, so a CI step can gate on them directly:
 
-- `0` — every eval ran and every gate check passed
-- `1` — an eval file failed to run (bundle/execution error), or the flags were misconfigured (e.g. a bad `--minScore` spec, a missing `--baseline` directory)
-- `2` — every eval ran, but a `--minScore` threshold or `--baseline` regression check failed
+- `0` — every eval ran, the gate performed at least one check, and every check passed
+- `1` — the run could not be gated: an eval file failed to run, or the configuration was invalid (bad `--minScore` spec, out-of-range threshold, `--baseline` missing, unreadable, or containing no results)
+- `2` — every eval ran, but a gate check failed
 
-With `--json`, stdout stays a single parseable JSON document. Without any gate flags it's the eval result(s), unchanged. With `--minScore` and/or `--baseline` set, it's wrapped as `{ "results": ..., "gate": { "passed": boolean, "checks": [...] } }` — safe to pipe to `jq` either way.
+#### The gate fails closed
 
-The gate itself is also available as a plain function for use outside the CLI — see `applyGate()` in `@llmops/sdk/eval`.
+A gate reports success only when it actually verified something. These all **fail** rather than passing quietly:
+
+- an evaluator named in `--minScore` that appears in no result (typo, renamed evaluator)
+- a baseline eval with no matching eval in the current run (renamed or deleted eval)
+- an eval that recorded datapoint or evaluator errors — a failed datapoint scores 0 and can otherwise drag a mean into looking fine, or be excluded and make it look better than it is
+- a gate that ended up performing zero checks
+
+Invalid configuration is deliberately separated from a failed gate: `1` means "this gate could not be trusted to run", `2` means "it ran and something regressed". Configuration is validated up front, before any eval executes, so a typo does not cost a full (and possibly paid) eval run.
+
+#### JSON output
+
+With `--json`, stdout stays a single parseable JSON document. Without any gate flags it's the eval result(s), unchanged. With `--minScore` and/or `--baseline` set, it's wrapped as `{ "results": ..., "gate": { "passed": boolean, "checks": [...] } }` — safe to pipe to `jq` either way. Each entry in `checks` carries its `type` (`min-score`, `regression`, `baseline-missing`, `errors`), the numbers behind the verdict, and a `message` when it failed closed.
+
+The gate itself is also available as a plain function for use outside the CLI — see `applyGate()` in `@llmops/sdk/eval`, which throws on invalid configuration and returns the same `checks` array.

--- a/packages/cli/src/commands/eval.ts
+++ b/packages/cli/src/commands/eval.ts
@@ -14,14 +14,29 @@ import {
   number as numberOption,
   string,
 } from '@drizzle-team/brocli';
-import type { GateResult } from '@llmops/sdk/eval';
+import type { EvaluateResult, GateCheck, GateResult } from '@llmops/sdk/eval';
 import { applyGate } from '@llmops/sdk/eval';
 import chalk from 'chalk';
-import { loadLatestResults, parseMinScoreSpec } from '../lib/gate';
+import {
+  buildJsonOutput,
+  byEvalName,
+  EXIT_EVAL_ERROR,
+  loadLatestResults,
+  parseMaxRegression,
+  parseMinScoreSpec,
+  resolveExitCode,
+} from '../lib/gate';
 
-/** Exit codes: 0 = pass, 1 = eval execution error, 2 = gate check failed. */
-const EXIT_EVAL_ERROR = 1;
-const EXIT_GATE_FAILURE = 2;
+function describeCheck(check: GateCheck): string {
+  if (check.message) return check.message;
+
+  if (check.type === 'min-score') {
+    return `score=${check.score?.toFixed(2)} min=${check.threshold}`;
+  }
+
+  const sign = (check.delta ?? 0) >= 0 ? '+' : '';
+  return `${check.baseline?.toFixed(2)} → ${check.candidate?.toFixed(2)} (delta ${sign}${check.delta?.toFixed(2)}, max regression ${check.maxRegression})`;
+}
 
 function printGateReport(gate: GateResult) {
   const RESET = '\x1b[0m';
@@ -31,21 +46,23 @@ function printGateReport(gate: GateResult) {
   const RED = '\x1b[31m';
 
   console.log(`\n${BOLD}Gate${RESET}  ${DIM}${'─'.repeat(40)}${RESET}`);
+
+  if (gate.checks.length === 0) {
+    console.log(`  ${RED}✗${RESET} ${DIM}no checks ran${RESET}`);
+  }
+
   for (const check of gate.checks) {
     const icon = check.passed ? `${GREEN}✓${RESET}` : `${RED}✗${RESET}`;
-    const label = `${check.eval} ${DIM}›${RESET} ${check.evaluator}`;
-    const detail =
-      check.type === 'min-score'
-        ? check.message
-          ? check.message
-          : `score=${check.score?.toFixed(2)} min=${check.threshold}`
-        : `${check.baseline?.toFixed(2)} → ${check.candidate?.toFixed(2)}  ${DIM}(delta ${check.delta && check.delta >= 0 ? '+' : ''}${check.delta?.toFixed(2)}, max regression ${check.maxRegression})${RESET}`;
-    console.log(`  ${icon} ${label}  ${DIM}${detail}${RESET}`);
+    const label = check.evaluator
+      ? `${check.eval} ${DIM}›${RESET} ${check.evaluator}`
+      : check.eval;
+    console.log(`  ${icon} ${label}  ${DIM}${describeCheck(check)}${RESET}`);
   }
+
   console.log(
     gate.passed
       ? `${GREEN}Gate passed${RESET}`
-      : `${RED}Gate failed${RESET} — ${gate.checks.filter((c) => !c.passed).length} check(s) did not pass`,
+      : `${RED}Gate failed${RESET} — ${gate.checks.filter((c) => !c.passed).length} of ${gate.checks.length} check(s) did not pass`,
   );
 }
 
@@ -58,7 +75,7 @@ function findEvalFiles(target: string): string[] {
 
   if (!existsSync(resolved)) {
     console.error(chalk.red(`Path not found: ${target}`));
-    process.exit(1);
+    process.exit(EXIT_EVAL_ERROR);
   }
 
   const stat = statSync(resolved);
@@ -198,20 +215,38 @@ export const evalCommand = command({
   handler: async (opts) => {
     const target = opts.target;
     const jsonOutput = opts.json === true;
-    const files = findEvalFiles(target);
 
-    if (opts.maxRegression !== undefined && !opts.baseline) {
-      console.error(
-        chalk.red('--maxRegression requires --baseline to be set.'),
-      );
-      process.exit(EXIT_EVAL_ERROR);
-    }
-
+    // Validate gate configuration before touching the filesystem or running
+    // anything, so a misconfigured flag fails immediately rather than after a
+    // full (and potentially paid) eval run.
     let minScoreThresholds: Record<string, number> | undefined;
+    let maxRegression = 0;
+    let baselineResults: Record<string, EvaluateResult> | undefined;
+
     try {
+      if (opts.maxRegression !== undefined && !opts.baseline) {
+        throw new Error('--maxRegression requires --baseline to be set.');
+      }
+
       minScoreThresholds = opts.minScore
         ? parseMinScoreSpec(opts.minScore)
         : undefined;
+      maxRegression = parseMaxRegression(opts.maxRegression);
+
+      if (opts.baseline) {
+        const baselineDir = resolve(opts.baseline);
+        if (!existsSync(baselineDir)) {
+          throw new Error(`Baseline directory not found: ${opts.baseline}`);
+        }
+
+        const loaded = loadLatestResults(baselineDir);
+        if (loaded.length === 0) {
+          throw new Error(
+            `Baseline directory contains no eval results: ${opts.baseline}`,
+          );
+        }
+        baselineResults = byEvalName(loaded);
+      }
     } catch (err) {
       console.error(
         chalk.red(err instanceof Error ? err.message : String(err)),
@@ -219,14 +254,8 @@ export const evalCommand = command({
       process.exit(EXIT_EVAL_ERROR);
     }
 
-    if (opts.baseline && !existsSync(resolve(opts.baseline))) {
-      console.error(
-        chalk.red(`Baseline directory not found: ${opts.baseline}`),
-      );
-      process.exit(EXIT_EVAL_ERROR);
-    }
-
-    const gateEnabled = Boolean(minScoreThresholds || opts.baseline);
+    const gateEnabled = Boolean(minScoreThresholds || baselineResults);
+    const files = findEvalFiles(target);
 
     if (files.length === 0) {
       console.error(
@@ -234,7 +263,7 @@ export const evalCommand = command({
           `No eval files found. Create files matching *.eval.ts or *.eval.js in ${target}`,
         ),
       );
-      process.exit(1);
+      process.exit(EXIT_EVAL_ERROR);
     }
 
     if (!jsonOutput) {
@@ -280,24 +309,25 @@ export const evalCommand = command({
     // requiring --json, so thresholds and baselines work in either mode.
     let gate: GateResult | undefined;
     if (gateEnabled && !hasErrors) {
-      const currentResults = loadLatestResults(
-        resolve(opts.outputDir),
-        runStartedAt,
-      );
-      const baselineResults = opts.baseline
-        ? loadLatestResults(resolve(opts.baseline))
-        : undefined;
-
-      gate = applyGate(Object.values(currentResults), {
-        minScore: minScoreThresholds,
-        baseline: baselineResults,
-        maxRegression: opts.maxRegression ?? 0,
-      });
+      try {
+        gate = applyGate(
+          loadLatestResults(resolve(opts.outputDir), runStartedAt),
+          {
+            minScore: minScoreThresholds,
+            baseline: baselineResults,
+            maxRegression,
+          },
+        );
+      } catch (err) {
+        console.error(
+          chalk.red(err instanceof Error ? err.message : String(err)),
+        );
+        process.exit(EXIT_EVAL_ERROR);
+      }
     }
 
     if (jsonOutput) {
-      const results = jsonResults.length === 1 ? jsonResults[0] : jsonResults;
-      const output = gate ? { results, gate } : results;
+      const output = buildJsonOutput(jsonResults, gate);
       process.stdout.write(`${JSON.stringify(output, null, 2)}\n`);
     }
 
@@ -342,12 +372,9 @@ export const evalCommand = command({
       printGateReport(gate);
     }
 
-    if (hasErrors) {
-      process.exit(EXIT_EVAL_ERROR);
-    }
-
-    if (gate && !gate.passed) {
-      process.exit(EXIT_GATE_FAILURE);
+    const exitCode = resolveExitCode({ hasErrors, gate });
+    if (exitCode !== 0) {
+      process.exit(exitCode);
     }
   },
 });

--- a/packages/cli/src/commands/eval.ts
+++ b/packages/cli/src/commands/eval.ts
@@ -11,9 +11,43 @@ import { basename, join, resolve } from 'node:path';
 import {
   boolean as booleanOption,
   command,
+  number as numberOption,
   string,
 } from '@drizzle-team/brocli';
+import type { GateResult } from '@llmops/sdk/eval';
+import { applyGate } from '@llmops/sdk/eval';
 import chalk from 'chalk';
+import { loadLatestResults, parseMinScoreSpec } from '../lib/gate';
+
+/** Exit codes: 0 = pass, 1 = eval execution error, 2 = gate check failed. */
+const EXIT_EVAL_ERROR = 1;
+const EXIT_GATE_FAILURE = 2;
+
+function printGateReport(gate: GateResult) {
+  const RESET = '\x1b[0m';
+  const DIM = '\x1b[2m';
+  const BOLD = '\x1b[1m';
+  const GREEN = '\x1b[32m';
+  const RED = '\x1b[31m';
+
+  console.log(`\n${BOLD}Gate${RESET}  ${DIM}${'─'.repeat(40)}${RESET}`);
+  for (const check of gate.checks) {
+    const icon = check.passed ? `${GREEN}✓${RESET}` : `${RED}✗${RESET}`;
+    const label = `${check.eval} ${DIM}›${RESET} ${check.evaluator}`;
+    const detail =
+      check.type === 'min-score'
+        ? check.message
+          ? check.message
+          : `score=${check.score?.toFixed(2)} min=${check.threshold}`
+        : `${check.baseline?.toFixed(2)} → ${check.candidate?.toFixed(2)}  ${DIM}(delta ${check.delta && check.delta >= 0 ? '+' : ''}${check.delta?.toFixed(2)}, max regression ${check.maxRegression})${RESET}`;
+    console.log(`  ${icon} ${label}  ${DIM}${detail}${RESET}`);
+  }
+  console.log(
+    gate.passed
+      ? `${GREEN}Gate passed${RESET}`
+      : `${RED}Gate failed${RESET} — ${gate.checks.filter((c) => !c.passed).length} check(s) did not pass`,
+  );
+}
 
 /**
  * Find eval files from a path (file or directory).
@@ -145,11 +179,54 @@ export const evalCommand = command({
       .desc('Output directory for results')
       .alias('o'),
     json: booleanOption().desc('Output results as JSON to stdout').alias('j'),
+    minScore: string()
+      .desc(
+        'Fail if an evaluator\'s mean score is below a threshold. Format: "evaluator=threshold[,evaluator=threshold...]"',
+      )
+      .alias('m'),
+    baseline: string()
+      .desc(
+        "Directory of baseline eval results (e.g. a previous run's --outputDir) to check for score regressions",
+      )
+      .alias('b'),
+    maxRegression: numberOption()
+      .desc(
+        "Max allowed drop in an evaluator's mean score vs --baseline before failing. Requires --baseline. Default: 0",
+      )
+      .alias('r'),
   },
   handler: async (opts) => {
     const target = opts.target;
     const jsonOutput = opts.json === true;
     const files = findEvalFiles(target);
+
+    if (opts.maxRegression !== undefined && !opts.baseline) {
+      console.error(
+        chalk.red('--maxRegression requires --baseline to be set.'),
+      );
+      process.exit(EXIT_EVAL_ERROR);
+    }
+
+    let minScoreThresholds: Record<string, number> | undefined;
+    try {
+      minScoreThresholds = opts.minScore
+        ? parseMinScoreSpec(opts.minScore)
+        : undefined;
+    } catch (err) {
+      console.error(
+        chalk.red(err instanceof Error ? err.message : String(err)),
+      );
+      process.exit(EXIT_EVAL_ERROR);
+    }
+
+    if (opts.baseline && !existsSync(resolve(opts.baseline))) {
+      console.error(
+        chalk.red(`Baseline directory not found: ${opts.baseline}`),
+      );
+      process.exit(EXIT_EVAL_ERROR);
+    }
+
+    const gateEnabled = Boolean(minScoreThresholds || opts.baseline);
 
     if (files.length === 0) {
       console.error(
@@ -176,6 +253,7 @@ export const evalCommand = command({
 
     let hasErrors = false;
     const jsonResults: unknown[] = [];
+    const runStartedAt = Date.now();
 
     for (const file of files) {
       const name = basename(file);
@@ -197,8 +275,29 @@ export const evalCommand = command({
       }
     }
 
+    // Run the CI gate against the results this invocation just produced.
+    // Reads back from outputDir (evaluate() always saves there) instead of
+    // requiring --json, so thresholds and baselines work in either mode.
+    let gate: GateResult | undefined;
+    if (gateEnabled && !hasErrors) {
+      const currentResults = loadLatestResults(
+        resolve(opts.outputDir),
+        runStartedAt,
+      );
+      const baselineResults = opts.baseline
+        ? loadLatestResults(resolve(opts.baseline))
+        : undefined;
+
+      gate = applyGate(Object.values(currentResults), {
+        minScore: minScoreThresholds,
+        baseline: baselineResults,
+        maxRegression: opts.maxRegression ?? 0,
+      });
+    }
+
     if (jsonOutput) {
-      const output = jsonResults.length === 1 ? jsonResults[0] : jsonResults;
+      const results = jsonResults.length === 1 ? jsonResults[0] : jsonResults;
+      const output = gate ? { results, gate } : results;
       process.stdout.write(`${JSON.stringify(output, null, 2)}\n`);
     }
 
@@ -239,8 +338,16 @@ export const evalCommand = command({
       }
     }
 
+    if (gate && !jsonOutput) {
+      printGateReport(gate);
+    }
+
     if (hasErrors) {
-      process.exit(1);
+      process.exit(EXIT_EVAL_ERROR);
+    }
+
+    if (gate && !gate.passed) {
+      process.exit(EXIT_GATE_FAILURE);
     }
   },
 });

--- a/packages/cli/src/commands/eval.ts
+++ b/packages/cli/src/commands/eval.ts
@@ -14,7 +14,7 @@ import {
   number as numberOption,
   string,
 } from '@drizzle-team/brocli';
-import type { EvaluateResult, GateCheck, GateResult } from '@llmops/sdk/eval';
+import type { EvaluateResult, GateResult } from '@llmops/sdk/eval';
 import { applyGate } from '@llmops/sdk/eval';
 import chalk from 'chalk';
 import {
@@ -26,45 +26,7 @@ import {
   parseMinScoreSpec,
   resolveExitCode,
 } from '../lib/gate';
-
-function describeCheck(check: GateCheck): string {
-  if (check.message) return check.message;
-
-  if (check.type === 'min-score') {
-    return `score=${check.score?.toFixed(2)} min=${check.threshold}`;
-  }
-
-  const sign = (check.delta ?? 0) >= 0 ? '+' : '';
-  return `${check.baseline?.toFixed(2)} → ${check.candidate?.toFixed(2)} (delta ${sign}${check.delta?.toFixed(2)}, max regression ${check.maxRegression})`;
-}
-
-function printGateReport(gate: GateResult) {
-  const RESET = '\x1b[0m';
-  const DIM = '\x1b[2m';
-  const BOLD = '\x1b[1m';
-  const GREEN = '\x1b[32m';
-  const RED = '\x1b[31m';
-
-  console.log(`\n${BOLD}Gate${RESET}  ${DIM}${'─'.repeat(40)}${RESET}`);
-
-  if (gate.checks.length === 0) {
-    console.log(`  ${RED}✗${RESET} ${DIM}no checks ran${RESET}`);
-  }
-
-  for (const check of gate.checks) {
-    const icon = check.passed ? `${GREEN}✓${RESET}` : `${RED}✗${RESET}`;
-    const label = check.evaluator
-      ? `${check.eval} ${DIM}›${RESET} ${check.evaluator}`
-      : check.eval;
-    console.log(`  ${icon} ${label}  ${DIM}${describeCheck(check)}${RESET}`);
-  }
-
-  console.log(
-    gate.passed
-      ? `${GREEN}Gate passed${RESET}`
-      : `${RED}Gate failed${RESET} — ${gate.checks.filter((c) => !c.passed).length} of ${gate.checks.length} check(s) did not pass`,
-  );
-}
+import { printGateReport } from '../lib/gate-report';
 
 /**
  * Find eval files from a path (file or directory).

--- a/packages/cli/src/lib/gate-report.ts
+++ b/packages/cli/src/lib/gate-report.ts
@@ -1,0 +1,50 @@
+import type { GateCheck, GateResult } from '@llmops/sdk/eval';
+
+const RESET = '\x1b[0m';
+const DIM = '\x1b[2m';
+const BOLD = '\x1b[1m';
+const GREEN = '\x1b[32m';
+const RED = '\x1b[31m';
+
+/**
+ * One-line human description of a single gate check, used by printGateReport.
+ * Falls back to the check's own `message` (set for checks that failed closed,
+ * e.g. an unmatched evaluator) before rendering the type-specific numbers.
+ */
+export function describeCheck(check: GateCheck): string {
+  if (check.message) return check.message;
+
+  if (check.type === 'min-score') {
+    return `score=${check.score?.toFixed(2)} min=${check.threshold}`;
+  }
+
+  const sign = (check.delta ?? 0) >= 0 ? '+' : '';
+  return `${check.baseline?.toFixed(2)} → ${check.candidate?.toFixed(2)} (delta ${sign}${check.delta?.toFixed(2)}, max regression ${check.maxRegression})`;
+}
+
+/**
+ * Renders a GateResult to stdout for the CLI's non-JSON mode. Pure
+ * presentation over an already-computed gate — see applyGate() in
+ * @llmops/sdk/eval for how checks are produced.
+ */
+export function printGateReport(gate: GateResult): void {
+  console.log(`\n${BOLD}Gate${RESET}  ${DIM}${'─'.repeat(40)}${RESET}`);
+
+  if (gate.checks.length === 0) {
+    console.log(`  ${RED}✗${RESET} ${DIM}no checks ran${RESET}`);
+  }
+
+  for (const check of gate.checks) {
+    const icon = check.passed ? `${GREEN}✓${RESET}` : `${RED}✗${RESET}`;
+    const label = check.evaluator
+      ? `${check.eval} ${DIM}›${RESET} ${check.evaluator}`
+      : check.eval;
+    console.log(`  ${icon} ${label}  ${DIM}${describeCheck(check)}${RESET}`);
+  }
+
+  console.log(
+    gate.passed
+      ? `${GREEN}Gate passed${RESET}`
+      : `${RED}Gate failed${RESET} — ${gate.checks.filter((c) => !c.passed).length} of ${gate.checks.length} check(s) did not pass`,
+  );
+}

--- a/packages/cli/src/lib/gate.ts
+++ b/packages/cli/src/lib/gate.ts
@@ -1,0 +1,98 @@
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { join, relative, sep } from 'node:path';
+import type { EvaluateResult } from '@llmops/sdk/eval';
+
+/**
+ * Parses a `--minScore` spec string like `"accuracy=0.8,exact=0.95"` into
+ * `{ accuracy: 0.8, exact: 0.95 }`. Throws on malformed entries so typos
+ * fail fast instead of silently skipping a threshold.
+ */
+export function parseMinScoreSpec(spec: string): Record<string, number> {
+  const thresholds: Record<string, number> = {};
+
+  for (const rawPair of spec.split(',')) {
+    const pair = rawPair.trim();
+    if (!pair) continue;
+
+    const eq = pair.indexOf('=');
+    const name = eq === -1 ? '' : pair.slice(0, eq).trim();
+    const value = eq === -1 ? Number.NaN : Number(pair.slice(eq + 1).trim());
+
+    if (!name || Number.isNaN(value)) {
+      throw new Error(
+        `Invalid --minScore entry "${pair}". Expected format "evaluator=threshold", e.g. "accuracy=0.8".`,
+      );
+    }
+
+    thresholds[name] = value;
+  }
+
+  if (Object.keys(thresholds).length === 0) {
+    throw new Error(
+      '--minScore requires at least one "evaluator=threshold" entry.',
+    );
+  }
+
+  return thresholds;
+}
+
+interface ResultFile {
+  /** Eval name, reconstructed from its path relative to the results dir. */
+  name: string;
+  path: string;
+  timestamp: number;
+}
+
+function collectResultFiles(dir: string, base: string): ResultFile[] {
+  const files: ResultFile[] = [];
+  const entries = readdirSync(dir, { withFileTypes: true });
+
+  for (const entry of entries) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...collectResultFiles(full, base));
+      continue;
+    }
+    if (!entry.isFile() || !entry.name.endsWith('.json')) continue;
+
+    const timestamp = Number(entry.name.slice(0, -'.json'.length));
+    if (Number.isNaN(timestamp)) continue;
+
+    const name = relative(base, dir).split(sep).join('/');
+    files.push({ name, path: full, timestamp });
+  }
+
+  return files;
+}
+
+/**
+ * Loads the most recent saved eval result per eval name from a results
+ * directory (the layout produced by evaluate()'s outputDir). When
+ * `sinceTimestamp` is given, only files written at or after that time are
+ * considered — used to isolate the results produced by the current `eval`
+ * invocation from older runs left in the same directory.
+ */
+export function loadLatestResults(
+  dir: string,
+  sinceTimestamp?: number,
+): Record<string, EvaluateResult> {
+  if (!existsSync(dir)) return {};
+
+  const files = collectResultFiles(dir, dir).filter(
+    (f) => sinceTimestamp === undefined || f.timestamp >= sinceTimestamp,
+  );
+
+  const latestByName = new Map<string, ResultFile>();
+  for (const file of files) {
+    const existing = latestByName.get(file.name);
+    if (!existing || file.timestamp > existing.timestamp) {
+      latestByName.set(file.name, file);
+    }
+  }
+
+  const results: Record<string, EvaluateResult> = {};
+  for (const [name, file] of latestByName) {
+    results[name] = JSON.parse(readFileSync(file.path, 'utf8'));
+  }
+  return results;
+}

--- a/packages/cli/src/lib/gate.ts
+++ b/packages/cli/src/lib/gate.ts
@@ -1,11 +1,17 @@
 import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { join, relative, sep } from 'node:path';
-import type { EvaluateResult } from '@llmops/sdk/eval';
+import type { EvaluateResult, GateResult } from '@llmops/sdk/eval';
+
+/** Exit codes: 0 = pass, 1 = eval execution or configuration error, 2 = gate check failed. */
+export const EXIT_OK = 0;
+export const EXIT_EVAL_ERROR = 1;
+export const EXIT_GATE_FAILURE = 2;
 
 /**
  * Parses a `--minScore` spec string like `"accuracy=0.8,exact=0.95"` into
- * `{ accuracy: 0.8, exact: 0.95 }`. Throws on malformed entries so typos
- * fail fast instead of silently skipping a threshold.
+ * `{ accuracy: 0.8, exact: 0.95 }`. Throws on malformed entries and on
+ * thresholds outside [0, 1] so typos fail fast instead of silently
+ * weakening or disabling a gate.
  */
 export function parseMinScoreSpec(spec: string): Record<string, number> {
   const thresholds: Record<string, number> = {};
@@ -16,11 +22,18 @@ export function parseMinScoreSpec(spec: string): Record<string, number> {
 
     const eq = pair.indexOf('=');
     const name = eq === -1 ? '' : pair.slice(0, eq).trim();
-    const value = eq === -1 ? Number.NaN : Number(pair.slice(eq + 1).trim());
+    const raw = eq === -1 ? '' : pair.slice(eq + 1).trim();
+    const value = raw === '' ? Number.NaN : Number(raw);
 
-    if (!name || Number.isNaN(value)) {
+    if (!name || !Number.isFinite(value)) {
       throw new Error(
         `Invalid --minScore entry "${pair}". Expected format "evaluator=threshold", e.g. "accuracy=0.8".`,
+      );
+    }
+
+    if (value < 0 || value > 1) {
+      throw new Error(
+        `Invalid --minScore threshold for "${name}": ${value}. Thresholds must be between 0 and 1.`,
       );
     }
 
@@ -34,6 +47,27 @@ export function parseMinScoreSpec(spec: string): Record<string, number> {
   }
 
   return thresholds;
+}
+
+/**
+ * Validates `--maxRegression`. Returns the default of 0 when unset.
+ */
+export function parseMaxRegression(value: number | undefined): number {
+  if (value === undefined) return 0;
+
+  if (!Number.isFinite(value)) {
+    throw new Error(
+      `Invalid --maxRegression: ${value}. Expected a finite number between 0 and 1.`,
+    );
+  }
+
+  if (value < 0 || value > 1) {
+    throw new Error(
+      `Invalid --maxRegression: ${value}. Must be between 0 and 1.`,
+    );
+  }
+
+  return value;
 }
 
 interface ResultFile {
@@ -71,12 +105,16 @@ function collectResultFiles(dir: string, base: string): ResultFile[] {
  * `sinceTimestamp` is given, only files written at or after that time are
  * considered — used to isolate the results produced by the current `eval`
  * invocation from older runs left in the same directory.
+ *
+ * Throws with the offending path if a result file cannot be read or parsed,
+ * so a corrupt baseline surfaces as a configuration error rather than
+ * quietly shrinking the set of things the gate checks.
  */
 export function loadLatestResults(
   dir: string,
   sinceTimestamp?: number,
-): Record<string, EvaluateResult> {
-  if (!existsSync(dir)) return {};
+): EvaluateResult[] {
+  if (!existsSync(dir)) return [];
 
   const files = collectResultFiles(dir, dir).filter(
     (f) => sinceTimestamp === undefined || f.timestamp >= sinceTimestamp,
@@ -90,9 +128,60 @@ export function loadLatestResults(
     }
   }
 
-  const results: Record<string, EvaluateResult> = {};
-  for (const [name, file] of latestByName) {
-    results[name] = JSON.parse(readFileSync(file.path, 'utf8'));
+  const results: EvaluateResult[] = [];
+  for (const file of latestByName.values()) {
+    let parsed: EvaluateResult;
+    try {
+      parsed = JSON.parse(readFileSync(file.path, 'utf8'));
+    } catch (err) {
+      throw new Error(
+        `Could not read eval result ${file.path}: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
+    results.push(parsed);
   }
   return results;
+}
+
+/**
+ * Keys results by their recorded eval name, which is what applyGate matches
+ * candidates and baselines on.
+ */
+export function byEvalName(
+  results: EvaluateResult[],
+): Record<string, EvaluateResult> {
+  const map: Record<string, EvaluateResult> = {};
+  for (const result of results) {
+    map[result.name] = result;
+  }
+  return map;
+}
+
+/**
+ * Shape written to stdout under `--json`. Without a gate the eval result(s)
+ * are emitted unchanged; with one they are wrapped alongside the gate so a
+ * caller can read both from a single parse.
+ */
+export function buildJsonOutput(
+  evalResults: unknown[],
+  gate?: GateResult,
+): unknown {
+  const results = evalResults.length === 1 ? evalResults[0] : evalResults;
+  return gate ? { results, gate } : results;
+}
+
+/**
+ * The CLI's exit contract, as a pure decision:
+ * an eval that failed to run outranks a gate verdict, and a gate that did
+ * not pass exits 2.
+ */
+export function resolveExitCode(input: {
+  hasErrors: boolean;
+  gate?: GateResult;
+}): number {
+  if (input.hasErrors) return EXIT_EVAL_ERROR;
+  if (input.gate && !input.gate.passed) return EXIT_GATE_FAILURE;
+  return EXIT_OK;
 }

--- a/packages/cli/src/tests/gate-report.test.ts
+++ b/packages/cli/src/tests/gate-report.test.ts
@@ -1,0 +1,159 @@
+import type { GateCheck, GateResult } from '@llmops/sdk/eval';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { describeCheck, printGateReport } from '../lib/gate-report';
+
+const ANSI_PATTERN = new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, 'g');
+
+// Strips ANSI escape codes so assertions read the same in any terminal.
+function stripAnsi(value: string): string {
+  return value.replace(ANSI_PATTERN, '');
+}
+
+describe('describeCheck', () => {
+  it('renders a passing min-score check', () => {
+    const check: GateCheck = {
+      eval: 'support-bot',
+      evaluator: 'accuracy',
+      type: 'min-score',
+      score: 0.92,
+      threshold: 0.8,
+      passed: true,
+    };
+    expect(describeCheck(check)).toBe('score=0.92 min=0.8');
+  });
+
+  it('renders a regression check with a negative delta', () => {
+    const check: GateCheck = {
+      eval: 'support-bot',
+      evaluator: 'accuracy',
+      type: 'regression',
+      baseline: 0.9,
+      candidate: 0.7,
+      delta: -0.2,
+      maxRegression: 0,
+      passed: false,
+    };
+    expect(describeCheck(check)).toBe(
+      '0.90 → 0.70 (delta -0.20, max regression 0)',
+    );
+  });
+
+  it('renders a regression check with a positive delta with an explicit sign', () => {
+    const check: GateCheck = {
+      eval: 'support-bot',
+      evaluator: 'accuracy',
+      type: 'regression',
+      baseline: 0.7,
+      candidate: 0.9,
+      delta: 0.2,
+      maxRegression: 0,
+      passed: true,
+    };
+    expect(describeCheck(check)).toBe(
+      '0.70 → 0.90 (delta +0.20, max regression 0)',
+    );
+  });
+
+  it('prefers the check message over type-specific formatting when present', () => {
+    const check: GateCheck = {
+      eval: 'support-bot',
+      evaluator: 'typo',
+      type: 'min-score',
+      threshold: 0.8,
+      passed: false,
+      message: 'evaluator "typo" was not found in any eval result',
+    };
+    expect(describeCheck(check)).toBe(
+      'evaluator "typo" was not found in any eval result',
+    );
+  });
+});
+
+describe('printGateReport', () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+  });
+
+  function loggedLines(): string[] {
+    return logSpy.mock.calls.map((args: unknown[]) =>
+      stripAnsi(String(args[0])),
+    );
+  }
+
+  it('reports a whole-eval check without an evaluator label', () => {
+    const gate: GateResult = {
+      passed: false,
+      checks: [
+        {
+          eval: 'support-bot',
+          type: 'baseline-missing',
+          passed: false,
+          message:
+            'baseline eval "support-bot" has no matching result in this run',
+        },
+      ],
+    };
+
+    printGateReport(gate);
+
+    const lines = loggedLines();
+    expect(lines[1]).toBe(
+      '  ✗ support-bot  baseline eval "support-bot" has no matching result in this run',
+    );
+  });
+
+  it('reports an evaluator-level check with the "eval › evaluator" label', () => {
+    const gate: GateResult = {
+      passed: true,
+      checks: [
+        {
+          eval: 'support-bot',
+          evaluator: 'accuracy',
+          type: 'min-score',
+          score: 0.9,
+          threshold: 0.8,
+          passed: true,
+        },
+      ],
+    };
+
+    printGateReport(gate);
+
+    expect(loggedLines()[1]).toBe(
+      '  ✓ support-bot › accuracy  score=0.90 min=0.8',
+    );
+  });
+
+  it('prints a placeholder line when the gate performed no checks', () => {
+    printGateReport({ passed: false, checks: [] });
+    expect(loggedLines()).toContain('  ✗ no checks ran');
+  });
+
+  it('summarizes a pass with no per-check failure count', () => {
+    printGateReport({ passed: true, checks: [] });
+    expect(loggedLines().at(-1)).toBe('Gate passed');
+  });
+
+  it('summarizes a failure with the count of failing vs total checks', () => {
+    const gate: GateResult = {
+      passed: false,
+      checks: [
+        { eval: 'a', evaluator: 'x', type: 'min-score', passed: true },
+        { eval: 'a', evaluator: 'y', type: 'min-score', passed: false },
+        { eval: 'a', evaluator: 'z', type: 'min-score', passed: false },
+      ],
+    };
+
+    printGateReport(gate);
+
+    expect(loggedLines().at(-1)).toBe(
+      'Gate failed — 2 of 3 check(s) did not pass',
+    );
+  });
+});

--- a/packages/cli/src/tests/gate.test.ts
+++ b/packages/cli/src/tests/gate.test.ts
@@ -1,8 +1,19 @@
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import type { GateResult } from '@llmops/sdk/eval';
 import { afterEach, describe, expect, it } from 'vitest';
-import { loadLatestResults, parseMinScoreSpec } from '../lib/gate';
+import {
+  buildJsonOutput,
+  byEvalName,
+  EXIT_EVAL_ERROR,
+  EXIT_GATE_FAILURE,
+  EXIT_OK,
+  loadLatestResults,
+  parseMaxRegression,
+  parseMinScoreSpec,
+  resolveExitCode,
+} from '../lib/gate';
 
 describe('parseMinScoreSpec', () => {
   it('parses a single evaluator=threshold pair', () => {
@@ -26,8 +37,43 @@ describe('parseMinScoreSpec', () => {
     );
   });
 
+  it('rejects an empty threshold', () => {
+    expect(() => parseMinScoreSpec('accuracy=')).toThrow(/Invalid --minScore/);
+  });
+
   it('rejects an empty spec', () => {
     expect(() => parseMinScoreSpec('')).toThrow(/requires at least one/);
+  });
+
+  it.each([
+    ['negative', 'accuracy=-0.1'],
+    ['above one', 'accuracy=1.5'],
+    ['infinite', 'accuracy=Infinity'],
+  ])('rejects a %s threshold', (_label, spec) => {
+    expect(() => parseMinScoreSpec(spec)).toThrow(/Invalid --minScore/);
+  });
+
+  it('accepts the inclusive bounds 0 and 1', () => {
+    expect(parseMinScoreSpec('a=0,b=1')).toEqual({ a: 0, b: 1 });
+  });
+});
+
+describe('parseMaxRegression', () => {
+  it('defaults to 0 when unset', () => {
+    expect(parseMaxRegression(undefined)).toBe(0);
+  });
+
+  it('accepts a value inside [0, 1]', () => {
+    expect(parseMaxRegression(0.05)).toBe(0.05);
+  });
+
+  it.each([
+    ['negative', -0.1],
+    ['above one', 1.5],
+    ['not finite', Number.NaN],
+    ['infinite', Number.POSITIVE_INFINITY],
+  ])('rejects a %s value', (_label, value) => {
+    expect(() => parseMaxRegression(value)).toThrow(/--maxRegression/);
   });
 });
 
@@ -46,17 +92,22 @@ describe('loadLatestResults', () => {
     }
   });
 
-  function writeResult(dir: string, name: string, timestamp: number) {
+  function writeResult(
+    dir: string,
+    name: string,
+    timestamp: number,
+    body?: string,
+  ) {
     const target = join(dir, ...name.split('/'));
     mkdirSync(target, { recursive: true });
     writeFileSync(
       join(target, `${timestamp}.json`),
-      JSON.stringify({ name, runId: `run-${timestamp}`, scores: {} }),
+      body ?? JSON.stringify({ name, runId: `run-${timestamp}`, scores: {} }),
     );
   }
 
-  it('returns an empty map when the directory does not exist', () => {
-    expect(loadLatestResults(join(tmpdir(), 'does-not-exist'))).toEqual({});
+  it('returns nothing when the directory does not exist', () => {
+    expect(loadLatestResults(join(tmpdir(), 'does-not-exist'))).toEqual([]);
   });
 
   it('picks the most recent file per eval name', () => {
@@ -65,7 +116,8 @@ describe('loadLatestResults', () => {
     writeResult(dir, 'support-bot', 2000);
 
     const results = loadLatestResults(dir);
-    expect(results['support-bot'].runId).toBe('run-2000');
+    expect(results).toHaveLength(1);
+    expect(results[0].runId).toBe('run-2000');
   });
 
   it('reconstructs nested variant names from directory structure', () => {
@@ -73,18 +125,99 @@ describe('loadLatestResults', () => {
     writeResult(dir, 'model-comparison/concise', 1000);
     writeResult(dir, 'model-comparison/verbose', 1000);
 
-    const results = loadLatestResults(dir);
-    expect(Object.keys(results).sort()).toEqual([
-      'model-comparison/concise',
-      'model-comparison/verbose',
-    ]);
+    expect(
+      loadLatestResults(dir)
+        .map((r) => r.name)
+        .sort(),
+    ).toEqual(['model-comparison/concise', 'model-comparison/verbose']);
   });
 
   it('filters out files older than sinceTimestamp', () => {
     const dir = tempDir();
     writeResult(dir, 'support-bot', 1000);
 
-    expect(loadLatestResults(dir, 2000)).toEqual({});
-    expect(loadLatestResults(dir, 500)).toHaveProperty('support-bot');
+    expect(loadLatestResults(dir, 2000)).toEqual([]);
+    expect(loadLatestResults(dir, 500)).toHaveLength(1);
+  });
+
+  it('throws with the offending path when a result file is corrupt', () => {
+    const dir = tempDir();
+    writeResult(dir, 'support-bot', 1000, '{ not valid json');
+
+    expect(() => loadLatestResults(dir)).toThrow(/Could not read eval result/);
+    expect(() => loadLatestResults(dir)).toThrow(/support-bot/);
+  });
+});
+
+describe('byEvalName', () => {
+  it('keys results by their recorded eval name', () => {
+    const a = { name: 'a', runId: '1' } as never;
+    const b = { name: 'b', runId: '2' } as never;
+    expect(byEvalName([a, b])).toEqual({ a, b });
+  });
+});
+
+describe('buildJsonOutput', () => {
+  const gate: GateResult = {
+    passed: false,
+    checks: [{ eval: 'a', evaluator: 'x', type: 'min-score', passed: false }],
+  };
+
+  it('emits a single eval result unwrapped when there is no gate', () => {
+    expect(buildJsonOutput([{ name: 'a' }])).toEqual({ name: 'a' });
+  });
+
+  it('emits an array when several eval files ran and there is no gate', () => {
+    expect(buildJsonOutput([{ name: 'a' }, { name: 'b' }])).toEqual([
+      { name: 'a' },
+      { name: 'b' },
+    ]);
+  });
+
+  it('wraps results alongside the gate when one ran', () => {
+    expect(buildJsonOutput([{ name: 'a' }], gate)).toEqual({
+      results: { name: 'a' },
+      gate,
+    });
+  });
+
+  it('keeps the wrapper parseable as a single document', () => {
+    const output = buildJsonOutput([{ name: 'a' }], gate);
+    expect(JSON.parse(JSON.stringify(output))).toHaveProperty(
+      'gate.passed',
+      false,
+    );
+  });
+});
+
+describe('resolveExitCode', () => {
+  const passing: GateResult = { passed: true, checks: [] };
+  const failing: GateResult = { passed: false, checks: [] };
+
+  it('exits 0 when nothing failed and no gate ran', () => {
+    expect(resolveExitCode({ hasErrors: false })).toBe(EXIT_OK);
+  });
+
+  it('exits 0 when the gate passed', () => {
+    expect(resolveExitCode({ hasErrors: false, gate: passing })).toBe(EXIT_OK);
+  });
+
+  it('exits 2 when the gate failed', () => {
+    expect(resolveExitCode({ hasErrors: false, gate: failing })).toBe(
+      EXIT_GATE_FAILURE,
+    );
+  });
+
+  it('exits 1 when an eval failed to run, with no gate', () => {
+    expect(resolveExitCode({ hasErrors: true })).toBe(EXIT_EVAL_ERROR);
+  });
+
+  it('prefers the execution error over a gate verdict', () => {
+    expect(resolveExitCode({ hasErrors: true, gate: failing })).toBe(
+      EXIT_EVAL_ERROR,
+    );
+    expect(resolveExitCode({ hasErrors: true, gate: passing })).toBe(
+      EXIT_EVAL_ERROR,
+    );
   });
 });

--- a/packages/cli/src/tests/gate.test.ts
+++ b/packages/cli/src/tests/gate.test.ts
@@ -1,0 +1,90 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { loadLatestResults, parseMinScoreSpec } from '../lib/gate';
+
+describe('parseMinScoreSpec', () => {
+  it('parses a single evaluator=threshold pair', () => {
+    expect(parseMinScoreSpec('accuracy=0.8')).toEqual({ accuracy: 0.8 });
+  });
+
+  it('parses multiple comma-separated pairs and trims whitespace', () => {
+    expect(parseMinScoreSpec(' accuracy=0.8, exact = 1 ')).toEqual({
+      accuracy: 0.8,
+      exact: 1,
+    });
+  });
+
+  it('rejects an entry missing "="', () => {
+    expect(() => parseMinScoreSpec('accuracy')).toThrow(/Invalid --minScore/);
+  });
+
+  it('rejects a non-numeric threshold', () => {
+    expect(() => parseMinScoreSpec('accuracy=high')).toThrow(
+      /Invalid --minScore/,
+    );
+  });
+
+  it('rejects an empty spec', () => {
+    expect(() => parseMinScoreSpec('')).toThrow(/requires at least one/);
+  });
+});
+
+describe('loadLatestResults', () => {
+  const dirs: string[] = [];
+
+  function tempDir(): string {
+    const dir = mkdtempSync(join(tmpdir(), 'llmops-gate-'));
+    dirs.push(dir);
+    return dir;
+  }
+
+  afterEach(() => {
+    for (const dir of dirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  function writeResult(dir: string, name: string, timestamp: number) {
+    const target = join(dir, ...name.split('/'));
+    mkdirSync(target, { recursive: true });
+    writeFileSync(
+      join(target, `${timestamp}.json`),
+      JSON.stringify({ name, runId: `run-${timestamp}`, scores: {} }),
+    );
+  }
+
+  it('returns an empty map when the directory does not exist', () => {
+    expect(loadLatestResults(join(tmpdir(), 'does-not-exist'))).toEqual({});
+  });
+
+  it('picks the most recent file per eval name', () => {
+    const dir = tempDir();
+    writeResult(dir, 'support-bot', 1000);
+    writeResult(dir, 'support-bot', 2000);
+
+    const results = loadLatestResults(dir);
+    expect(results['support-bot'].runId).toBe('run-2000');
+  });
+
+  it('reconstructs nested variant names from directory structure', () => {
+    const dir = tempDir();
+    writeResult(dir, 'model-comparison/concise', 1000);
+    writeResult(dir, 'model-comparison/verbose', 1000);
+
+    const results = loadLatestResults(dir);
+    expect(Object.keys(results).sort()).toEqual([
+      'model-comparison/concise',
+      'model-comparison/verbose',
+    ]);
+  });
+
+  it('filters out files older than sinceTimestamp', () => {
+    const dir = tempDir();
+    writeResult(dir, 'support-bot', 1000);
+
+    expect(loadLatestResults(dir, 2000)).toEqual({});
+    expect(loadLatestResults(dir, 500)).toHaveProperty('support-bot');
+  });
+});

--- a/packages/sdk/src/eval/gate.test.ts
+++ b/packages/sdk/src/eval/gate.test.ts
@@ -5,6 +5,7 @@ import type { EvaluateResult, VariantEvaluateResult } from './types';
 function makeResult(
   name: string,
   scores: Record<string, number>,
+  overrides: Partial<EvaluateResult> = {},
 ): EvaluateResult {
   const stats = Object.fromEntries(
     Object.entries(scores).map(([key, mean]) => [
@@ -20,6 +21,7 @@ function makeResult(
     count: 1,
     errors: 0,
     results: [],
+    ...overrides,
   };
 }
 
@@ -99,14 +101,10 @@ describe('applyGate', () => {
     expect(gate.passed).toBe(true);
   });
 
-  it('skips evals and evaluators absent from the baseline instead of failing', () => {
+  it('skips baseline evaluators absent from the candidate scores', () => {
     const gate = applyGate(
       [makeResult('new-eval', { accuracy: 0.9, extra: 1 })],
-      {
-        baseline: {
-          'new-eval': makeResult('new-eval', { accuracy: 0.9 }),
-        },
-      },
+      { baseline: { 'new-eval': makeResult('new-eval', { accuracy: 0.9 }) } },
     );
 
     expect(gate.passed).toBe(true);
@@ -128,8 +126,120 @@ describe('applyGate', () => {
     );
 
     expect(gate.passed).toBe(false);
-    expect(gate.checks).toHaveLength(3);
     expect(gate.checks.find((c) => c.eval === 'sql-gen')?.passed).toBe(false);
+  });
+
+  // ── Fail-closed behaviour ─────────────────────────────────────────────
+
+  it('fails when there are no candidate results to check at all', () => {
+    const gate = applyGate([], {
+      baseline: { 'support-bot': makeResult('support-bot', { accuracy: 0.9 }) },
+    });
+
+    expect(gate.passed).toBe(false);
+    expect(gate.checks).toContainEqual(
+      expect.objectContaining({
+        eval: 'support-bot',
+        type: 'baseline-missing',
+        passed: false,
+      }),
+    );
+  });
+
+  it('fails when no candidate eval name matches the baseline', () => {
+    const gate = applyGate([makeResult('renamed-bot', { accuracy: 0.1 })], {
+      baseline: { 'support-bot': makeResult('support-bot', { accuracy: 0.9 }) },
+    });
+
+    expect(gate.passed).toBe(false);
+    expect(
+      gate.checks.find((c) => c.type === 'baseline-missing')?.message,
+    ).toMatch(/no matching result/);
+  });
+
+  it('surfaces a dropped eval while still checking the ones that remain', () => {
+    const gate = applyGate([makeResult('kept', { accuracy: 0.9 })], {
+      baseline: {
+        kept: makeResult('kept', { accuracy: 0.9 }),
+        dropped: makeResult('dropped', { accuracy: 0.9 }),
+      },
+    });
+
+    expect(gate.passed).toBe(false);
+    expect(gate.checks.filter((c) => c.passed)).toHaveLength(1);
+    expect(
+      gate.checks.filter((c) => c.type === 'baseline-missing'),
+    ).toHaveLength(1);
+  });
+
+  it('never reports a pass when it performed no checks', () => {
+    const gate = applyGate([makeResult('unrelated', { other: 1 })], {
+      // matches nothing in the candidate, so no comparison happens
+      baseline: { unrelated: makeResult('unrelated', { missing: 1 }) },
+    });
+
+    expect(gate.checks).toHaveLength(0);
+    expect(gate.passed).toBe(false);
+  });
+
+  it('fails when a candidate eval recorded datapoint errors, even if means look fine', () => {
+    const gate = applyGate(
+      [makeResult('support-bot', { accuracy: 1 }, { count: 4, errors: 2 })],
+      { minScore: { accuracy: 0.8 } },
+    );
+
+    expect(gate.passed).toBe(false);
+    const errorCheck = gate.checks.find((c) => c.type === 'errors');
+    expect(errorCheck).toMatchObject({ passed: false, errors: 2 });
+    expect(errorCheck?.message).toMatch(/failed to produce a score/);
+  });
+
+  // ── Misconfiguration ──────────────────────────────────────────────────
+
+  it('throws when a baseline is supplied with nothing to compare against', () => {
+    expect(() =>
+      applyGate([makeResult('a', { s: 1 })], { baseline: {} }),
+    ).toThrow(/contains no eval results/);
+  });
+
+  it('throws when neither minScore nor baseline is supplied', () => {
+    expect(() => applyGate([makeResult('a', { s: 1 })], {})).toThrow(
+      /provide minScore, baseline, or both/,
+    );
+  });
+
+  it.each([
+    ['below zero', -0.1],
+    ['above one', 1.5],
+    ['not finite', Number.NaN],
+    ['infinite', Number.POSITIVE_INFINITY],
+  ])('throws for a minScore threshold %s', (_label, threshold) => {
+    expect(() =>
+      applyGate([makeResult('a', { s: 1 })], { minScore: { s: threshold } }),
+    ).toThrow(/minScore\["s"\]/);
+  });
+
+  it.each([
+    ['below zero', -0.1],
+    ['above one', 2],
+    ['not finite', Number.NaN],
+  ])('throws for a maxRegression %s', (_label, maxRegression) => {
+    expect(() =>
+      applyGate([makeResult('a', { s: 1 })], {
+        baseline: { a: makeResult('a', { s: 1 }) },
+        maxRegression,
+      }),
+    ).toThrow(/maxRegression/);
+  });
+
+  it('accepts the inclusive bounds 0 and 1', () => {
+    expect(() =>
+      applyGate([makeResult('a', { s: 1 })], {
+        minScore: { s: 0 },
+        baseline: { a: makeResult('a', { s: 1 }) },
+        maxRegression: 1,
+      }),
+    ).not.toThrow();
   });
 });
 
@@ -155,5 +265,28 @@ describe('flattenEvaluateResult', () => {
       'model-comparison/concise',
       'model-comparison/verbose',
     ]);
+  });
+
+  it('produces names that match the baseline keys a variants gate compares on', () => {
+    const variantResult: VariantEvaluateResult = {
+      name: 'model-comparison',
+      runId: 'run-2',
+      durationMs: 1,
+      variants: { concise: makeResult('ignored', { accuracy: 0.5 }) },
+    };
+
+    const gate = applyGate(flattenEvaluateResult(variantResult), {
+      baseline: {
+        'model-comparison/concise': makeResult('model-comparison/concise', {
+          accuracy: 0.9,
+        }),
+      },
+    });
+
+    expect(gate.checks).toHaveLength(1);
+    expect(gate.checks[0]).toMatchObject({
+      type: 'regression',
+      passed: false,
+    });
   });
 });

--- a/packages/sdk/src/eval/gate.test.ts
+++ b/packages/sdk/src/eval/gate.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from 'vitest';
+import { applyGate, flattenEvaluateResult } from './gate';
+import type { EvaluateResult, VariantEvaluateResult } from './types';
+
+function makeResult(
+  name: string,
+  scores: Record<string, number>,
+): EvaluateResult {
+  const stats = Object.fromEntries(
+    Object.entries(scores).map(([key, mean]) => [
+      key,
+      { mean, min: mean, max: mean, median: mean, count: 1 },
+    ]),
+  );
+  return {
+    name,
+    runId: `run-${name}`,
+    scores: stats,
+    durationMs: 1,
+    count: 1,
+    errors: 0,
+    results: [],
+  };
+}
+
+describe('applyGate', () => {
+  it('passes when every evaluator meets its minimum score', () => {
+    const gate = applyGate([makeResult('support-bot', { accuracy: 0.9 })], {
+      minScore: { accuracy: 0.8 },
+    });
+
+    expect(gate.passed).toBe(true);
+    expect(gate.checks).toEqual([
+      {
+        eval: 'support-bot',
+        evaluator: 'accuracy',
+        type: 'min-score',
+        score: 0.9,
+        threshold: 0.8,
+        passed: true,
+      },
+    ]);
+  });
+
+  it('fails when an evaluator falls below its minimum score', () => {
+    const gate = applyGate([makeResult('support-bot', { accuracy: 0.5 })], {
+      minScore: { accuracy: 0.8 },
+    });
+
+    expect(gate.passed).toBe(false);
+    expect(gate.checks[0]).toMatchObject({ passed: false, score: 0.5 });
+  });
+
+  it('fails loudly when a threshold names an evaluator that never ran', () => {
+    const gate = applyGate([makeResult('support-bot', { accuracy: 0.9 })], {
+      minScore: { accuracy: 0.8, typo_evaluator: 0.5 },
+    });
+
+    expect(gate.passed).toBe(false);
+    const missing = gate.checks.find((c) => c.evaluator === 'typo_evaluator');
+    expect(missing?.passed).toBe(false);
+    expect(missing?.message).toMatch(/not found/);
+  });
+
+  it('passes a regression check when the candidate matches the baseline exactly (default maxRegression: 0)', () => {
+    const gate = applyGate([makeResult('support-bot', { accuracy: 0.8 })], {
+      baseline: { 'support-bot': makeResult('support-bot', { accuracy: 0.8 }) },
+    });
+
+    expect(gate.passed).toBe(true);
+    expect(gate.checks[0]).toMatchObject({
+      type: 'regression',
+      baseline: 0.8,
+      candidate: 0.8,
+      delta: 0,
+    });
+  });
+
+  it('fails a regression check when the candidate drops below the baseline', () => {
+    const gate = applyGate([makeResult('support-bot', { accuracy: 0.7 })], {
+      baseline: { 'support-bot': makeResult('support-bot', { accuracy: 0.9 }) },
+    });
+
+    expect(gate.passed).toBe(false);
+    expect(gate.checks[0]).toMatchObject({
+      passed: false,
+      baseline: 0.9,
+      candidate: 0.7,
+      delta: expect.closeTo(-0.2, 5),
+    });
+  });
+
+  it('tolerates a drop within maxRegression', () => {
+    const gate = applyGate([makeResult('support-bot', { accuracy: 0.86 })], {
+      baseline: { 'support-bot': makeResult('support-bot', { accuracy: 0.9 }) },
+      maxRegression: 0.05,
+    });
+
+    expect(gate.passed).toBe(true);
+  });
+
+  it('skips evals and evaluators absent from the baseline instead of failing', () => {
+    const gate = applyGate(
+      [makeResult('new-eval', { accuracy: 0.9, extra: 1 })],
+      {
+        baseline: {
+          'new-eval': makeResult('new-eval', { accuracy: 0.9 }),
+        },
+      },
+    );
+
+    expect(gate.passed).toBe(true);
+    expect(gate.checks).toHaveLength(1);
+  });
+
+  it('combines min-score and regression checks across multiple results', () => {
+    const gate = applyGate(
+      [
+        makeResult('support-bot', { accuracy: 0.9 }),
+        makeResult('sql-gen', { accuracy: 0.4 }),
+      ],
+      {
+        minScore: { accuracy: 0.8 },
+        baseline: {
+          'support-bot': makeResult('support-bot', { accuracy: 0.85 }),
+        },
+      },
+    );
+
+    expect(gate.passed).toBe(false);
+    expect(gate.checks).toHaveLength(3);
+    expect(gate.checks.find((c) => c.eval === 'sql-gen')?.passed).toBe(false);
+  });
+});
+
+describe('flattenEvaluateResult', () => {
+  it('returns a single-executor result unchanged', () => {
+    const result = makeResult('support-bot', { accuracy: 0.9 });
+    expect(flattenEvaluateResult(result)).toEqual([result]);
+  });
+
+  it('expands variants into name-qualified results', () => {
+    const variantResult: VariantEvaluateResult = {
+      name: 'model-comparison',
+      runId: 'run-1',
+      durationMs: 1,
+      variants: {
+        concise: makeResult('model-comparison/concise', { accuracy: 0.9 }),
+        verbose: makeResult('model-comparison/verbose', { accuracy: 0.7 }),
+      },
+    };
+
+    const flattened = flattenEvaluateResult(variantResult);
+    expect(flattened.map((r) => r.name)).toEqual([
+      'model-comparison/concise',
+      'model-comparison/verbose',
+    ]);
+  });
+});

--- a/packages/sdk/src/eval/gate.test.ts
+++ b/packages/sdk/src/eval/gate.test.ts
@@ -101,7 +101,7 @@ describe('applyGate', () => {
     expect(gate.passed).toBe(true);
   });
 
-  it('skips baseline evaluators absent from the candidate scores', () => {
+  it('allows a candidate-only evaluator as new coverage', () => {
     const gate = applyGate(
       [makeResult('new-eval', { accuracy: 0.9, extra: 1 })],
       { baseline: { 'new-eval': makeResult('new-eval', { accuracy: 0.9 }) } },
@@ -109,6 +109,88 @@ describe('applyGate', () => {
 
     expect(gate.passed).toBe(true);
     expect(gate.checks).toHaveLength(1);
+    expect(gate.checks[0]).toMatchObject({
+      evaluator: 'accuracy',
+      type: 'regression',
+    });
+  });
+
+  it('fails when a matched baseline eval loses an evaluator', () => {
+    const gate = applyGate([makeResult('support-bot', { accuracy: 0.9 })], {
+      baseline: {
+        'support-bot': makeResult('support-bot', {
+          accuracy: 0.9,
+          safety: 1,
+        }),
+      },
+    });
+
+    expect(gate.passed).toBe(false);
+    const missing = gate.checks.find((c) => c.type === 'evaluator-missing');
+    expect(missing).toMatchObject({
+      eval: 'support-bot',
+      evaluator: 'safety',
+      baseline: 1,
+      passed: false,
+    });
+    expect(missing?.message).toMatch(/produced no score in this run/);
+  });
+
+  it('still compares the surviving evaluator when another disappears', () => {
+    const gate = applyGate([makeResult('support-bot', { accuracy: 0.95 })], {
+      baseline: {
+        'support-bot': makeResult('support-bot', {
+          accuracy: 0.9,
+          safety: 1,
+        }),
+      },
+    });
+
+    // accuracy improved, so on its own the gate would have passed.
+    const regression = gate.checks.find((c) => c.type === 'regression');
+    expect(regression).toMatchObject({ evaluator: 'accuracy', passed: true });
+    expect(gate.checks.filter((c) => !c.passed)).toHaveLength(1);
+    expect(gate.passed).toBe(false);
+  });
+
+  it('reports every dropped evaluator, and only the dropped ones', () => {
+    const gate = applyGate(
+      [makeResult('support-bot', { accuracy: 0.9, added: 1 })],
+      {
+        baseline: {
+          'support-bot': makeResult('support-bot', {
+            accuracy: 0.9,
+            safety: 1,
+            tone: 0.5,
+          }),
+        },
+      },
+    );
+
+    expect(
+      gate.checks
+        .filter((c) => c.type === 'evaluator-missing')
+        .map((c) => c.evaluator)
+        .sort(),
+    ).toEqual(['safety', 'tone']);
+    expect(gate.passed).toBe(false);
+  });
+
+  it('does not report dropped evaluators for an unmatched baseline eval', () => {
+    // The whole eval is already reported as baseline-missing; listing each of
+    // its evaluators too would just be noise.
+    const gate = applyGate([makeResult('renamed', { accuracy: 0.9 })], {
+      baseline: {
+        'support-bot': makeResult('support-bot', { accuracy: 0.9, safety: 1 }),
+      },
+    });
+
+    expect(
+      gate.checks.filter((c) => c.type === 'evaluator-missing'),
+    ).toHaveLength(0);
+    expect(
+      gate.checks.filter((c) => c.type === 'baseline-missing'),
+    ).toHaveLength(1);
   });
 
   it('combines min-score and regression checks across multiple results', () => {
@@ -173,13 +255,27 @@ describe('applyGate', () => {
   });
 
   it('never reports a pass when it performed no checks', () => {
-    const gate = applyGate([makeResult('unrelated', { other: 1 })], {
-      // matches nothing in the candidate, so no comparison happens
-      baseline: { unrelated: makeResult('unrelated', { missing: 1 }) },
+    // Both sides match by name and neither recorded any evaluator, so nothing
+    // is comparable and no check is produced.
+    const gate = applyGate([makeResult('empty', {})], {
+      baseline: { empty: makeResult('empty', {}) },
     });
 
     expect(gate.checks).toHaveLength(0);
     expect(gate.passed).toBe(false);
+  });
+
+  it('reports a dropped evaluator rather than falling back to the zero-check guard', () => {
+    const gate = applyGate([makeResult('unrelated', { other: 1 })], {
+      baseline: { unrelated: makeResult('unrelated', { missing: 1 }) },
+    });
+
+    expect(gate.passed).toBe(false);
+    expect(gate.checks).toHaveLength(1);
+    expect(gate.checks[0]).toMatchObject({
+      type: 'evaluator-missing',
+      evaluator: 'missing',
+    });
   });
 
   it('fails when a candidate eval recorded datapoint errors, even if means look fine', () => {

--- a/packages/sdk/src/eval/gate.test.ts
+++ b/packages/sdk/src/eval/gate.test.ts
@@ -363,6 +363,45 @@ describe('flattenEvaluateResult', () => {
     ]);
   });
 
+  it('copies every EvaluateResult field onto the flattened entry without mutating the source variant', () => {
+    // Deliberately named differently from what flattening will produce, so a
+    // passing assertion on the source's `name` actually proves it was not
+    // written to in place.
+    const concise = makeResult(
+      'unflattened-name',
+      { accuracy: 0.9 },
+      { group: 'nightly', metadata: { model: 'gpt-mini' }, errors: 1 },
+    );
+    const variantResult: VariantEvaluateResult = {
+      name: 'model-comparison',
+      runId: 'run-1',
+      durationMs: 1,
+      variants: { concise },
+    };
+
+    const [flattened] = flattenEvaluateResult(variantResult);
+
+    // Every field carried over correctly, renamed to the qualified form.
+    // Spelled out explicitly (not `{ ...concise, name: ... }`) so this test
+    // does not depend on the same construct the fix moved away from.
+    expect(flattened).toEqual({
+      name: 'model-comparison/concise',
+      runId: concise.runId,
+      group: concise.group,
+      scores: concise.scores,
+      durationMs: concise.durationMs,
+      count: concise.count,
+      errors: concise.errors,
+      metadata: concise.metadata,
+      results: concise.results,
+    });
+    // A fresh object, not the same reference as the source variant.
+    expect(flattened).not.toBe(concise);
+    // The source variant itself was never written to.
+    expect(concise.name).toBe('unflattened-name');
+    expect(concise.group).toBe('nightly');
+  });
+
   it('produces names that match the baseline keys a variants gate compares on', () => {
     const variantResult: VariantEvaluateResult = {
       name: 'model-comparison',

--- a/packages/sdk/src/eval/gate.ts
+++ b/packages/sdk/src/eval/gate.ts
@@ -1,0 +1,106 @@
+import type {
+  EvaluateResult,
+  GateCheck,
+  GateOptions,
+  GateResult,
+  VariantEvaluateResult,
+} from './types';
+
+/**
+ * Flattens the result of evaluate() into a list of `EvaluateResult`s.
+ * A single-executor run is returned as-is; a variants run is expanded to
+ * one entry per variant, named `${name}/${variantName}` to match how
+ * evaluate() persists variant results to disk.
+ */
+export function flattenEvaluateResult<D = unknown, O = unknown>(
+  result: EvaluateResult<D, O> | VariantEvaluateResult<D, O>,
+): EvaluateResult<D, O>[] {
+  if ('variants' in result) {
+    return Object.entries(result.variants).map(([variantName, variant]) => ({
+      ...variant,
+      name: `${result.name}/${variantName}`,
+    }));
+  }
+  return [result];
+}
+
+/**
+ * Checks eval results against score thresholds and/or a baseline, for use
+ * as a CI regression gate. Pure and synchronous — safe to call from a CI
+ * script or the `llmops eval` CLI.
+ *
+ * ```ts
+ * const result = await evaluate({ ... });
+ * const gate = applyGate(flattenEvaluateResult(result), {
+ *   minScore: { accuracy: 0.8 },
+ * });
+ * if (!gate.passed) process.exit(1);
+ * ```
+ */
+export function applyGate(
+  results: EvaluateResult[],
+  options: GateOptions,
+): GateResult {
+  const { minScore, baseline, maxRegression = 0 } = options;
+  const checks: GateCheck[] = [];
+  const matchedThresholds = new Set<string>();
+
+  for (const result of results) {
+    if (minScore) {
+      for (const [evaluator, threshold] of Object.entries(minScore)) {
+        const stats = result.scores[evaluator];
+        if (!stats) continue;
+        matchedThresholds.add(evaluator);
+        checks.push({
+          eval: result.name,
+          evaluator,
+          type: 'min-score',
+          score: stats.mean,
+          threshold,
+          passed: stats.mean >= threshold,
+        });
+      }
+    }
+
+    if (baseline) {
+      const baselineResult = baseline[result.name];
+      if (!baselineResult) continue;
+
+      for (const [evaluator, candidateStats] of Object.entries(result.scores)) {
+        const baselineStats = baselineResult.scores[evaluator];
+        if (!baselineStats) continue;
+
+        const delta = candidateStats.mean - baselineStats.mean;
+        checks.push({
+          eval: result.name,
+          evaluator,
+          type: 'regression',
+          baseline: baselineStats.mean,
+          candidate: candidateStats.mean,
+          delta,
+          maxRegression,
+          passed: delta >= -maxRegression,
+        });
+      }
+    }
+  }
+
+  if (minScore) {
+    for (const evaluator of Object.keys(minScore)) {
+      if (matchedThresholds.has(evaluator)) continue;
+      checks.push({
+        eval: results.map((r) => r.name).join(', ') || '(no results)',
+        evaluator,
+        type: 'min-score',
+        threshold: minScore[evaluator],
+        passed: false,
+        message: `evaluator "${evaluator}" was not found in any eval result`,
+      });
+    }
+  }
+
+  return {
+    passed: checks.every((check) => check.passed),
+    checks,
+  };
+}

--- a/packages/sdk/src/eval/gate.ts
+++ b/packages/sdk/src/eval/gate.ts
@@ -44,8 +44,10 @@ function assertUnitInterval(value: number, label: string): void {
  *
  * The gate fails closed. It reports `passed: true` only when it actually
  * performed checks and every one of them passed; anything it could not
- * verify (an evaluator that never ran, a baseline eval with no candidate,
- * an eval that recorded errors) is a failing check, not a skipped one.
+ * verify (an evaluator that never ran, a baseline eval with no candidate, a
+ * baseline evaluator the candidate dropped, an eval that recorded errors) is
+ * a failing check, not a skipped one. Evaluators only the candidate has are
+ * treated as new coverage and pass silently.
  *
  * Throws on misconfiguration — out-of-range thresholds, or a baseline that
  * contains no runs to compare against. Callers should treat a throw as a
@@ -125,6 +127,7 @@ export function applyGate(
 
       for (const [evaluator, candidateStats] of Object.entries(result.scores)) {
         const baselineStats = baselineResult.scores[evaluator];
+        // Evaluators only the candidate has are new coverage, not a regression.
         if (!baselineStats) continue;
 
         const delta = candidateStats.mean - baselineStats.mean;
@@ -137,6 +140,23 @@ export function applyGate(
           delta,
           maxRegression,
           passed: delta >= -maxRegression,
+        });
+      }
+
+      // An evaluator the baseline had and the candidate does not is lost
+      // coverage: comparing only what survived would let a deleted safety
+      // check read as "no regression".
+      for (const [evaluator, baselineStats] of Object.entries(
+        baselineResult.scores,
+      )) {
+        if (result.scores[evaluator]) continue;
+        checks.push({
+          eval: result.name,
+          evaluator,
+          type: 'evaluator-missing',
+          baseline: baselineStats.mean,
+          passed: false,
+          message: `evaluator "${evaluator}" is in the baseline for "${result.name}" but produced no score in this run`,
         });
       }
     }

--- a/packages/sdk/src/eval/gate.ts
+++ b/packages/sdk/src/eval/gate.ts
@@ -24,10 +24,32 @@ export function flattenEvaluateResult<D = unknown, O = unknown>(
   return [result];
 }
 
+function assertUnitInterval(value: number, label: string): void {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    throw new Error(
+      `applyGate(): ${label} must be a finite number, got ${value}`,
+    );
+  }
+  if (value < 0 || value > 1) {
+    throw new Error(
+      `applyGate(): ${label} must be between 0 and 1, got ${value}`,
+    );
+  }
+}
+
 /**
  * Checks eval results against score thresholds and/or a baseline, for use
  * as a CI regression gate. Pure and synchronous — safe to call from a CI
  * script or the `llmops eval` CLI.
+ *
+ * The gate fails closed. It reports `passed: true` only when it actually
+ * performed checks and every one of them passed; anything it could not
+ * verify (an evaluator that never ran, a baseline eval with no candidate,
+ * an eval that recorded errors) is a failing check, not a skipped one.
+ *
+ * Throws on misconfiguration — out-of-range thresholds, or a baseline that
+ * contains no runs to compare against. Callers should treat a throw as a
+ * setup error, distinct from a failed gate.
  *
  * ```ts
  * const result = await evaluate({ ... });
@@ -42,10 +64,45 @@ export function applyGate(
   options: GateOptions,
 ): GateResult {
   const { minScore, baseline, maxRegression = 0 } = options;
+
+  if (minScore) {
+    if (Object.keys(minScore).length === 0) {
+      throw new Error('applyGate(): minScore was provided but is empty');
+    }
+    for (const [evaluator, threshold] of Object.entries(minScore)) {
+      assertUnitInterval(threshold, `minScore["${evaluator}"]`);
+    }
+  }
+
+  assertUnitInterval(maxRegression, 'maxRegression');
+
+  if (baseline && Object.keys(baseline).length === 0) {
+    throw new Error(
+      'applyGate(): baseline was provided but contains no eval results to compare against',
+    );
+  }
+
+  if (!minScore && !baseline) {
+    throw new Error('applyGate(): provide minScore, baseline, or both');
+  }
+
   const checks: GateCheck[] = [];
   const matchedThresholds = new Set<string>();
+  const candidateNames = new Set(results.map((r) => r.name));
 
   for (const result of results) {
+    // An eval that recorded errors cannot vouch for its own scores: a failed
+    // datapoint contributes 0, which can look like a passing mean elsewhere.
+    if (result.errors > 0) {
+      checks.push({
+        eval: result.name,
+        type: 'errors',
+        errors: result.errors,
+        passed: false,
+        message: `${result.errors} of ${result.count} datapoint(s) failed to produce a score`,
+      });
+    }
+
     if (minScore) {
       for (const [evaluator, threshold] of Object.entries(minScore)) {
         const stats = result.scores[evaluator];
@@ -85,6 +142,20 @@ export function applyGate(
     }
   }
 
+  // A baseline eval with no candidate means the comparison silently lost
+  // coverage — a renamed or dropped eval must not read as "no regression".
+  if (baseline) {
+    for (const baselineName of Object.keys(baseline)) {
+      if (candidateNames.has(baselineName)) continue;
+      checks.push({
+        eval: baselineName,
+        type: 'baseline-missing',
+        passed: false,
+        message: `baseline eval "${baselineName}" has no matching result in this run`,
+      });
+    }
+  }
+
   if (minScore) {
     for (const evaluator of Object.keys(minScore)) {
       if (matchedThresholds.has(evaluator)) continue;
@@ -100,7 +171,8 @@ export function applyGate(
   }
 
   return {
-    passed: checks.every((check) => check.passed),
+    // No checks means nothing was verified, which is not a pass.
+    passed: checks.length > 0 && checks.every((check) => check.passed),
     checks,
   };
 }

--- a/packages/sdk/src/eval/gate.ts
+++ b/packages/sdk/src/eval/gate.ts
@@ -11,17 +11,37 @@ import type {
  * A single-executor run is returned as-is; a variants run is expanded to
  * one entry per variant, named `${name}/${variantName}` to match how
  * evaluate() persists variant results to disk.
+ *
+ * Field-by-field construction rather than `{ ...variant, name }`: listing
+ * each field makes the copied contract visible at the call site instead of
+ * hiding it behind a spread. It has no meaningful performance advantage over
+ * a spread here — both are a one-level shallow copy of a handful of fields —
+ * and it never mutates `variant`, which spread would not have either. The
+ * tradeoff is that this list must be kept in sync by hand: unlike a spread,
+ * it will not automatically pick up a field later added to `EvaluateResult`.
  */
 export function flattenEvaluateResult<D = unknown, O = unknown>(
   result: EvaluateResult<D, O> | VariantEvaluateResult<D, O>,
 ): EvaluateResult<D, O>[] {
-  if ('variants' in result) {
-    return Object.entries(result.variants).map(([variantName, variant]) => ({
-      ...variant,
-      name: `${result.name}/${variantName}`,
-    }));
+  if (!('variants' in result)) {
+    return [result];
   }
-  return [result];
+
+  const flattened: EvaluateResult<D, O>[] = [];
+  for (const [variantName, variant] of Object.entries(result.variants)) {
+    flattened.push({
+      name: `${result.name}/${variantName}`,
+      runId: variant.runId,
+      group: variant.group,
+      scores: variant.scores,
+      durationMs: variant.durationMs,
+      count: variant.count,
+      errors: variant.errors,
+      metadata: variant.metadata,
+      results: variant.results,
+    });
+  }
+  return flattened;
 }
 
 function assertUnitInterval(value: number, label: string): void {

--- a/packages/sdk/src/eval/index.ts
+++ b/packages/sdk/src/eval/index.ts
@@ -1,19 +1,23 @@
-export { evaluate } from './evaluate';
 export { compare } from './compare';
-export { judgeScorer } from './judge';
 export type { EvaluationDataset } from './dataset';
 export { InlineDataset } from './dataset';
+export { evaluate } from './evaluate';
+export { applyGate, flattenEvaluateResult } from './gate';
+export { judgeScorer } from './judge';
 export type {
+  CompareOptions,
+  CompareResult,
   Datapoint,
+  DatapointResult,
+  EvaluateOptions,
+  EvaluateResult,
   Evaluator,
   Executor,
-  EvaluateOptions,
-  DatapointResult,
-  ScoreStats,
-  EvaluateResult,
-  VariantEvaluateResult,
-  CompareOptions,
-  ScoreDelta,
-  CompareResult,
+  GateCheck,
+  GateOptions,
+  GateResult,
   JudgeScorerOptions,
+  ScoreDelta,
+  ScoreStats,
+  VariantEvaluateResult,
 } from './types';

--- a/packages/sdk/src/eval/types.ts
+++ b/packages/sdk/src/eval/types.ts
@@ -149,45 +149,63 @@ export interface GateOptions {
   /**
    * Minimum mean score required per evaluator name, keyed by evaluator name
    * as it appears in `EvaluateResult.scores`. A result whose mean is below
-   * the threshold fails the gate.
+   * the threshold fails the gate. Thresholds must be finite numbers in [0, 1].
+   *
+   * An evaluator named here that appears in no candidate result fails the
+   * gate rather than being skipped.
    */
   minScore?: Record<string, number>;
 
   /**
-   * Baseline runs to diff against, keyed by `EvaluateResult.name`. Only
-   * evaluators present in both the baseline and the candidate are checked.
+   * Baseline runs to diff against, keyed by `EvaluateResult.name`. Evaluators
+   * present in both the baseline and the candidate are compared; a baseline
+   * eval with no matching candidate fails the gate rather than being skipped.
+   *
+   * Passing an empty record throws — a regression gate that can compare
+   * nothing must not report success.
    */
   baseline?: Record<string, EvaluateResult>;
 
   /**
    * Maximum allowed drop in an evaluator's mean score vs its baseline
-   * before failing. Default: 0 (no regression allowed).
+   * before failing. Must be a finite number in [0, 1]. Default: 0
+   * (no regression allowed).
    */
   maxRegression?: number;
 }
 
 /**
- * A single threshold or regression check performed by applyGate().
+ * A single check performed by applyGate().
+ *
+ * - `min-score` — an evaluator's mean vs a configured threshold
+ * - `regression` — an evaluator's mean vs its baseline
+ * - `baseline-missing` — a baseline eval absent from the candidate run
+ * - `errors` — a candidate eval that recorded datapoint/evaluator errors
  */
 export interface GateCheck {
   /** `EvaluateResult.name` this check ran against. */
   eval: string;
-  /** Evaluator name (key in `EvaluateResult.scores`). */
-  evaluator: string;
-  type: 'min-score' | 'regression';
+  /** Evaluator name (key in `EvaluateResult.scores`). Absent for whole-eval checks. */
+  evaluator?: string;
+  type: 'min-score' | 'regression' | 'baseline-missing' | 'errors';
   score?: number;
   threshold?: number;
   baseline?: number;
   candidate?: number;
   delta?: number;
   maxRegression?: number;
+  /** Number of failed datapoints, for `errors` checks. */
+  errors?: number;
   passed: boolean;
-  /** Present when a check could not be evaluated as configured, e.g. an unmatched evaluator name. */
+  /** Human-readable reason, set for checks that fail closed rather than on a number. */
   message?: string;
 }
 
 /**
  * Result of applyGate(). `passed` is true only when every check passed.
+ *
+ * A gate that produced no checks at all is reported as `passed: false` —
+ * a gate that verified nothing has not been satisfied.
  */
 export interface GateResult {
   passed: boolean;

--- a/packages/sdk/src/eval/types.ts
+++ b/packages/sdk/src/eval/types.ts
@@ -158,8 +158,10 @@ export interface GateOptions {
 
   /**
    * Baseline runs to diff against, keyed by `EvaluateResult.name`. Evaluators
-   * present in both the baseline and the candidate are compared; a baseline
-   * eval with no matching candidate fails the gate rather than being skipped.
+   * present in both the baseline and the candidate are compared. A baseline
+   * eval with no matching candidate, or a baseline evaluator that produced no
+   * score in the candidate, fails the gate rather than being skipped;
+   * evaluators only the candidate has count as new coverage.
    *
    * Passing an empty record throws — a regression gate that can compare
    * nothing must not report success.
@@ -180,6 +182,9 @@ export interface GateOptions {
  * - `min-score` — an evaluator's mean vs a configured threshold
  * - `regression` — an evaluator's mean vs its baseline
  * - `baseline-missing` — a baseline eval absent from the candidate run
+ * - `evaluator-missing` — an evaluator in a matched baseline eval that produced
+ *   no score in the candidate run. Evaluators only the candidate has are new
+ *   coverage and are not reported.
  * - `errors` — a candidate eval that recorded datapoint/evaluator errors
  */
 export interface GateCheck {
@@ -187,7 +192,12 @@ export interface GateCheck {
   eval: string;
   /** Evaluator name (key in `EvaluateResult.scores`). Absent for whole-eval checks. */
   evaluator?: string;
-  type: 'min-score' | 'regression' | 'baseline-missing' | 'errors';
+  type:
+    | 'min-score'
+    | 'regression'
+    | 'baseline-missing'
+    | 'evaluator-missing'
+    | 'errors';
   score?: number;
   threshold?: number;
   baseline?: number;

--- a/packages/sdk/src/eval/types.ts
+++ b/packages/sdk/src/eval/types.ts
@@ -143,6 +143,58 @@ export interface CompareResult {
 }
 
 /**
+ * Options for applyGate().
+ */
+export interface GateOptions {
+  /**
+   * Minimum mean score required per evaluator name, keyed by evaluator name
+   * as it appears in `EvaluateResult.scores`. A result whose mean is below
+   * the threshold fails the gate.
+   */
+  minScore?: Record<string, number>;
+
+  /**
+   * Baseline runs to diff against, keyed by `EvaluateResult.name`. Only
+   * evaluators present in both the baseline and the candidate are checked.
+   */
+  baseline?: Record<string, EvaluateResult>;
+
+  /**
+   * Maximum allowed drop in an evaluator's mean score vs its baseline
+   * before failing. Default: 0 (no regression allowed).
+   */
+  maxRegression?: number;
+}
+
+/**
+ * A single threshold or regression check performed by applyGate().
+ */
+export interface GateCheck {
+  /** `EvaluateResult.name` this check ran against. */
+  eval: string;
+  /** Evaluator name (key in `EvaluateResult.scores`). */
+  evaluator: string;
+  type: 'min-score' | 'regression';
+  score?: number;
+  threshold?: number;
+  baseline?: number;
+  candidate?: number;
+  delta?: number;
+  maxRegression?: number;
+  passed: boolean;
+  /** Present when a check could not be evaluated as configured, e.g. an unmatched evaluator name. */
+  message?: string;
+}
+
+/**
+ * Result of applyGate(). `passed` is true only when every check passed.
+ */
+export interface GateResult {
+  passed: boolean;
+  checks: GateCheck[];
+}
+
+/**
  * Options for judgeScorer().
  */
 export interface JudgeScorerOptions {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -440,6 +440,9 @@ importers:
       uuid:
         specifier: ^13.0.0
         version: 13.0.0
+      zod:
+        specifier: ^4.3.5
+        version: 4.3.6
     devDependencies:
       '@hono/node-server':
         specifier: ^1.19.6


### PR DESCRIPTION
## Summary

- add public applyGate and flattenEvaluateResult APIs for evaluator score thresholds and baseline regression checks
- add CLI minScore, baseline, and maxRegression flags with clean JSON output and deterministic exit codes: 0 pass, 1 execution or configuration error, 2 failed gate
- fail closed when checks are empty, evals contain errors, baseline evals or evaluators disappear, or gate configuration is invalid
- add a pull-request workflow for frozen install, typecheck, tests, and package builds without external API secrets
- declare the app Zod runtime dependency, fixing the duplicate-resolution error that previously made the root typecheck fail
- document the CLI contract and CI usage

## Verification

- pnpm install --frozen-lockfile
- pnpm run typecheck: green across core, gateway, app, SDK, CLI, and standalone
- pnpm run test: core 22, gateway 16, app 12, SDK 48, CLI 31; all green
- pnpm run build: all five packages green
- end-to-end exit matrix: no flags 0, passing gate 0, threshold failure 2, renamed eval 2, removed evaluator 2, eval errors 2, empty baseline 1, invalid threshold 1
- changed files pass Biome and git diff checks